### PR TITLE
feat(profile): add profile visibility, public profile viewing, and user settings

### DIFF
--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -1,0 +1,115 @@
+{
+  "name": ".opencode",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@opencode-ai/plugin": "1.3.14"
+      }
+    },
+    "node_modules/@opencode-ai/plugin": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.3.14.tgz",
+      "integrity": "sha512-dIEko9B4KytL1pABotkSw2Rm3/BKXb+5Z4g4c/aXjVd2cu86UIsFz8orgMB4zsQOa0bECzESaQzHOKTn3gMEMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@opencode-ai/sdk": "1.3.14",
+        "zod": "4.1.8"
+      },
+      "peerDependencies": {
+        "@opentui/core": ">=0.1.96",
+        "@opentui/solid": ">=0.1.96"
+      },
+      "peerDependenciesMeta": {
+        "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/solid": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.3.14.tgz",
+      "integrity": "sha512-8sNOFYB86d3b2KiIiL6wtio4V9U0mKEiJAlehzuaigZWiZMsI11Gq1Fdq+tIf9RWNQNsZSMYFuofLabPWQs7qA==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "7.0.6"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.8",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,3 +94,9 @@ All work must be tied to a GitHub issue. Follow this workflow:
 ## Configuration & Secrets
 - Copy `/.env.example` to `/.env` and set required `VITE_*` values.
 - Do not commit secrets; `.env*` files are ignored by Git.
+
+## Programming Rules
+
+Detailed conventions live in `docs/programming-rules/`:
+
+- [Models](docs/programming-rules/models.md) — conventions for defining types, value enums, and barrel exports

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Cinelog Web
+
+See [AGENTS.md](AGENTS.md) for coding conventions and programming rules.

--- a/biome.json
+++ b/biome.json
@@ -176,7 +176,9 @@
 						"noCommonJs": "error",
 						"noNamespace": "error",
 						"useArrayLiterals": "error",
-						"useAsConstAssertion": "error"
+						"useAsConstAssertion": "error",
+						"useImportType": "error",
+						"useExportType": "error"
 					},
 					"suspicious": {
 						"noExplicitAny": "error",

--- a/docs/programming-rules/models.md
+++ b/docs/programming-rules/models.md
@@ -1,0 +1,38 @@
+# Model Conventions
+
+## Value Types (String Enums)
+
+Always define a `const` array as the single source of truth and derive the type from it.
+
+```ts
+export const FOO_VALUES = ['a', 'b', 'c'] as const;
+
+export type Foo = (typeof FOO_VALUES)[number];
+```
+
+Do **not** write a separate union type — it duplicates the array and can drift out of sync.
+
+## Request / Response Types
+
+Use `export type` for data shapes. Reference domain value types where applicable.
+
+```ts
+export type CreateFooRequest = {
+  name: string;
+  kind: Foo;
+};
+```
+
+## Barrel Exports
+
+Each `models/` directory must have an `index.ts` that re-exports all models explicitly:
+
+- Use `export type { X }` for type-only exports.
+- Use named exports `export { X }` for runtime values (const arrays, objects).
+- Do **not** use `export *` — keep exports explicit so unused values are not accidentally exposed.
+
+```ts
+export type { CreateFooRequest } from './create-foo-request';
+export type { Foo } from './foo';
+export { FOO_VALUES } from './foo';
+```

--- a/src/features/auth/components/RegistrationForm.tsx
+++ b/src/features/auth/components/RegistrationForm.tsx
@@ -15,6 +15,9 @@ import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { z } from 'zod';
+import { ProfileVisibilitySelect } from '@/features/profile/components/ProfileVisibilitySelect';
+import type { ProfileVisibility } from '@/lib/models';
+import { PROFILE_VISIBILITY_VALUES } from '@/lib/models';
 import { useAuthStore } from '../stores';
 
 type RegistrationSchema = {
@@ -25,6 +28,7 @@ type RegistrationSchema = {
 	handle: string;
 	dateOfBirth: Date;
 	bio?: string;
+	profileVisibility: ProfileVisibility;
 };
 
 export const RegistrationForm = () => {
@@ -46,6 +50,7 @@ export const RegistrationForm = () => {
 				message: t('RegistrationForm.validation.dobPast'),
 			}),
 			bio: z.string().optional(),
+			profileVisibility: z.enum(PROFILE_VISIBILITY_VALUES),
 		})
 		.strict();
 
@@ -59,6 +64,7 @@ export const RegistrationForm = () => {
 			handle: '',
 			dateOfBirth: undefined,
 			bio: '',
+			profileVisibility: 'private',
 		},
 	});
 
@@ -75,6 +81,7 @@ export const RegistrationForm = () => {
 				handle: data.handle,
 				dateOfBirth: data.dateOfBirth?.toISOString() ?? '',
 				bio: data.bio,
+				profileVisibility: data.profileVisibility,
 			});
 
 			navigate('/login');
@@ -211,6 +218,21 @@ export const RegistrationForm = () => {
 									placeholder={t('RegistrationForm.bioPlaceholder')}
 								/>
 							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+
+				<FormField
+					control={form.control}
+					name="profileVisibility"
+					render={({ field }) => (
+						<FormItem>
+							<FormLabel>{t('ProfileVisibilitySelect.label')}</FormLabel>
+							<ProfileVisibilitySelect
+								value={field.value}
+								onChange={(value) => field.onChange(value as ProfileVisibility)}
+							/>
 							<FormMessage />
 						</FormItem>
 					)}

--- a/src/features/auth/components/RegistrationForm.unit.test.tsx
+++ b/src/features/auth/components/RegistrationForm.unit.test.tsx
@@ -24,6 +24,33 @@ vi.mock('../stores', () => ({
 	useAuthStore: () => ({ register: mockRegister }),
 }));
 
+vi.mock('@/features/profile/components/ProfileVisibilitySelect', () => ({
+	ProfileVisibilitySelect: ({
+		value,
+		onChange,
+	}: {
+		value: string;
+		onChange: (value: string) => void;
+	}) => (
+		<div data-testid="profile-visibility-select" data-value={value}>
+			<button
+				type="button"
+				data-testid="select-public"
+				onClick={() => onChange('public')}
+			>
+				public
+			</button>
+			<button
+				type="button"
+				data-testid="select-private"
+				onClick={() => onChange('private')}
+			>
+				private
+			</button>
+		</div>
+	),
+}));
+
 const { shouldBypassValidation } = vi.hoisted(() => ({
 	shouldBypassValidation: { value: false },
 }));
@@ -113,6 +140,9 @@ describe('RegistrationForm', () => {
 			expect(
 				screen.getByPlaceholderText('RegistrationForm.bioPlaceholder')
 			).toBeInTheDocument();
+			expect(
+				screen.getByText('ProfileVisibilitySelect.label')
+			).toBeInTheDocument();
 		});
 
 		it('should render the submit button', () => {
@@ -178,6 +208,7 @@ describe('RegistrationForm', () => {
 						email: 'john@example.com',
 						password: 'password123',
 						handle: 'johndoe',
+						profileVisibility: 'private',
 					})
 				);
 			});
@@ -292,6 +323,36 @@ describe('RegistrationForm', () => {
 				expect(screen.getByText('fail')).toBeInTheDocument();
 			});
 			expect(mockNavigate).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('profile visibility', () => {
+		it('should default to private', () => {
+			render(<RegistrationForm />);
+
+			expect(screen.getByTestId('profile-visibility-select')).toHaveAttribute(
+				'data-value',
+				'private'
+			);
+		});
+
+		it('should send public profileVisibility when changed to public', async () => {
+			mockRegister.mockResolvedValueOnce(undefined);
+			render(<RegistrationForm />);
+
+			fillForm();
+			fireEvent.click(screen.getByTestId('select-public'));
+			fireEvent.click(
+				screen.getByRole('button', { name: 'RegistrationForm.submit' })
+			);
+
+			await waitFor(() => {
+				expect(mockRegister).toHaveBeenCalledWith(
+					expect.objectContaining({
+						profileVisibility: 'public',
+					})
+				);
+			});
 		});
 	});
 });

--- a/src/features/auth/models/register-request.ts
+++ b/src/features/auth/models/register-request.ts
@@ -1,3 +1,5 @@
+import type { ProfileVisibility } from '@/lib/models';
+
 export type RegisterRequest = {
 	firstName: string;
 	lastName: string;
@@ -6,4 +8,5 @@ export type RegisterRequest = {
 	handle: string;
 	dateOfBirth: string;
 	bio?: string;
+	profileVisibility: ProfileVisibility;
 };

--- a/src/features/auth/models/user-profile-response.ts
+++ b/src/features/auth/models/user-profile-response.ts
@@ -1,12 +1,10 @@
 import type { ProfileVisibility } from '@/lib/models';
 
-export type UserResponse = {
-	id: string;
+export type UserProfileResponse = {
 	firstName: string;
 	lastName: string;
-	email: string;
 	handle: string;
-	dateOfBirth: string;
 	bio?: string;
 	profileVisibility: ProfileVisibility;
+	dateOfBirth: string;
 };

--- a/src/features/auth/repositories/user-repository.ts
+++ b/src/features/auth/repositories/user-repository.ts
@@ -1,10 +1,19 @@
 import type { ChangePasswordRequest } from '@/features/profile/models/change-password-request';
 import type { UpdateProfileRequest } from '@/features/profile/models/update-profile-request';
 import { apiClient } from '@/lib/api/client';
+import type { UserProfileResponse } from '../models/user-profile-response';
 import type { UserResponse } from '../models/user-response';
 
 export const getUserInfo = async (): Promise<UserResponse> => {
 	return await apiClient.get('v1/users/info').json();
+};
+
+export const getProfile = async (
+	handle: string
+): Promise<UserProfileResponse> => {
+	return await apiClient
+		.get(`v1/users/${encodeURIComponent(handle)}/profile`)
+		.json();
 };
 
 export const updateProfile = async (

--- a/src/features/auth/schemas/registration.schema.ts
+++ b/src/features/auth/schemas/registration.schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { PROFILE_VISIBILITY_VALUES } from '@/lib/models';
 
 export const registrationSchema = z
 	.object({
@@ -11,6 +12,7 @@ export const registrationSchema = z
 			message: 'Date of birth must be in the past',
 		}),
 		bio: z.string().optional(),
+		profileVisibility: z.enum(PROFILE_VISIBILITY_VALUES),
 	})
 	.strict();
 

--- a/src/features/logs/models/watched-where.ts
+++ b/src/features/logs/models/watched-where.ts
@@ -7,11 +7,3 @@ export const WATCHED_WHERE_VALUES = [
 ] as const;
 
 export type WatchedWhere = (typeof WATCHED_WHERE_VALUES)[number];
-
-export const WATCHED_WHERE_LABELS: Record<WatchedWhere, string> = {
-	cinema: 'Cinema',
-	streaming: 'Streaming',
-	homeVideo: 'Home Video',
-	tv: 'TV',
-	other: 'Other',
-};

--- a/src/features/logs/repositories/log-repository.ts
+++ b/src/features/logs/repositories/log-repository.ts
@@ -26,6 +26,7 @@ export const createLog = async (
 };
 
 export const getLogs = async (
+	handle: string,
 	params: GetLogsParams = {}
 ): Promise<LogListResponse> => {
 	const searchParams: Record<string, string> = {};
@@ -37,7 +38,7 @@ export const getLogs = async (
 	if (params.dateWatchedTo) searchParams.dateWatchedTo = params.dateWatchedTo;
 
 	return apiClient
-		.get('v1/logs/', {
+		.get(`v1/logs/${encodeURIComponent(handle)}`, {
 			searchParams,
 		})
 		.json();

--- a/src/features/logs/stores/movieLogStore.unit.test.ts
+++ b/src/features/logs/stores/movieLogStore.unit.test.ts
@@ -8,7 +8,7 @@ vi.mock('../repositories', () => ({
 	updateLog: vi.fn(),
 }));
 
-import { LogCreateResponse } from '../models';
+import type { LogCreateResponse } from '../models';
 import { createLog, updateLog } from '../repositories';
 
 const mockCreateLog = vi.mocked(createLog);

--- a/src/features/movie/components/MovieLogItem.tsx
+++ b/src/features/movie/components/MovieLogItem.tsx
@@ -13,9 +13,13 @@ import { MovieVote } from './MovieVote';
 
 interface MovieLogItemProps {
 	log: LogListItem;
+	isDropdownMenuVisible?: boolean;
 }
 
-export const MovieLogItem = ({ log }: MovieLogItemProps) => {
+export const MovieLogItem = ({
+	log,
+	isDropdownMenuVisible,
+}: MovieLogItemProps) => {
 	const { t } = useTranslation();
 	const navigate = useNavigate();
 
@@ -84,23 +88,26 @@ export const MovieLogItem = ({ log }: MovieLogItemProps) => {
 				</div>
 			</div>
 
-			<div className="ml-auto">
-				<DropdownMenu>
-					<DropdownMenuTrigger className="outline-none">
-						<MoreVertical className="h-5 w-5" />
-					</DropdownMenuTrigger>
-					<DropdownMenuContent>
-						<DropdownMenuItem onClick={editMovieLog}>
-							{t('MovieLogItem.edit')}
-						</DropdownMenuItem>
-						{/* TODO: Implement delete functionality - see GitHub issue */}
-						{/* <DropdownMenuItem variant="destructive">
+			{isDropdownMenuVisible && (
+				<div className="ml-auto">
+					<DropdownMenu>
+						<DropdownMenuTrigger className="outline-none">
+							<MoreVertical className="h-5 w-5" />
+						</DropdownMenuTrigger>
+						<DropdownMenuContent>
+							<DropdownMenuItem onClick={editMovieLog}>
+								{t('MovieLogItem.edit')}
+							</DropdownMenuItem>
+
+							{/* TODO: Implement delete functionality - see GitHub issue */}
+							{/* <DropdownMenuItem variant="destructive">
 							{' '}
 							{t('MovieLogItem.delete')}
 						</DropdownMenuItem> */}
-					</DropdownMenuContent>
-				</DropdownMenu>
-			</div>
+						</DropdownMenuContent>
+					</DropdownMenu>
+				</div>
+			)}
 		</div>
 	);
 };

--- a/src/features/movie/components/MovieLogItem.unit.test.tsx
+++ b/src/features/movie/components/MovieLogItem.unit.test.tsx
@@ -255,11 +255,27 @@ describe('MovieLogItem', () => {
 		});
 	});
 
+	describe('Dropdown Menu Visibility', () => {
+		it('should render dropdown menu when isDropdownMenuVisible is true', () => {
+			const log = createMockLog();
+			render(<MovieLogItem log={log} isDropdownMenuVisible={true} />);
+
+			expect(screen.getByTestId('dropdown-trigger')).toBeInTheDocument();
+		});
+
+		it('should not render dropdown menu when isDropdownMenuVisible is false', () => {
+			const log = createMockLog();
+			render(<MovieLogItem log={log} isDropdownMenuVisible={false} />);
+
+			expect(screen.queryByTestId('dropdown-trigger')).not.toBeInTheDocument();
+		});
+	});
+
 	describe('Edit Movie Log', () => {
 		it('should call open with movieToEdit when edit menu item is clicked', async () => {
 			const user = userEvent.setup();
 			const log = createMockLog();
-			render(<MovieLogItem log={log} />);
+			render(<MovieLogItem log={log} isDropdownMenuVisible={true} />);
 
 			const editButton = screen.getByTestId('dropdown-item');
 			await user.click(editButton);

--- a/src/features/movie/components/MovieLogList.tsx
+++ b/src/features/movie/components/MovieLogList.tsx
@@ -4,9 +4,13 @@ import { MovieLogItem } from './MovieLogItem';
 
 interface MovieLogListProps {
 	logs: LogListItem[];
+	isDropdownMenuVisible?: boolean;
 }
 
-export const MovieLogList = ({ logs }: MovieLogListProps) => {
+export const MovieLogList = ({
+	logs,
+	isDropdownMenuVisible,
+}: MovieLogListProps) => {
 	const { t } = useTranslation();
 
 	if (logs.length === 0) {
@@ -23,7 +27,11 @@ export const MovieLogList = ({ logs }: MovieLogListProps) => {
 				{t('MovieLogList.watchedMovie', { count: logs.length })}
 			</h3>
 			{logs.map((log) => (
-				<MovieLogItem key={log.id} log={log} />
+				<MovieLogItem
+					key={log.id}
+					log={log}
+					isDropdownMenuVisible={isDropdownMenuVisible}
+				/>
 			))}
 		</div>
 	);

--- a/src/features/movie/components/MoviesWatched.tsx
+++ b/src/features/movie/components/MoviesWatched.tsx
@@ -10,10 +10,19 @@ import { useTranslation } from 'react-i18next';
 import type { LogListItem } from '@/features/logs/models';
 import { type GetLogsParams, getLogs } from '@/features/logs/repositories';
 import { useMovieLogDialogStore } from '@/features/logs/stores';
+import { extractApiError } from '@/lib/api/api-error';
 import { MovieLogList } from './MovieLogList';
 import { MoviesWatchedLoading } from './MoviesWatchedLoading';
 
-export const MoviesWatched = () => {
+interface MoviesWatchedProps {
+	handle: string;
+	isDropdownMenuVisible?: boolean;
+}
+
+export const MoviesWatched = ({
+	handle,
+	isDropdownMenuVisible,
+}: MoviesWatchedProps) => {
 	const { t } = useTranslation();
 	const [logs, setLogs] = useState<LogListItem[]>([]);
 	const [isLoading, setIsLoading] = useState(true);
@@ -39,10 +48,13 @@ export const MoviesWatched = () => {
 					params.dateWatchedTo = `${selectedYear}-12-31`;
 				}
 
-				const response = await getLogs(params);
+				const response = await getLogs(handle, params);
 				setLogs(response.logs);
 			} catch (err) {
-				if (err instanceof Error) {
+				const apiError = await extractApiError(err);
+				if (apiError?.error_code_name === 'PROFILE_NOT_PUBLIC') {
+					setError(t('ApiError.profileNotPublic'));
+				} else if (err instanceof Error) {
 					setError(err.message);
 				} else {
 					setError(t('MoviesWatched.errorLoading'));
@@ -53,7 +65,7 @@ export const MoviesWatched = () => {
 		};
 
 		fetchLogs();
-	}, [selectedYear, refreshCounter]);
+	}, [handle, selectedYear, refreshCounter, t]);
 
 	if (isLoading) {
 		return <MoviesWatchedLoading />;
@@ -69,7 +81,6 @@ export const MoviesWatched = () => {
 
 	return (
 		<div className="flex flex-col">
-			{/* Year Filter */}
 			<div className="p-4 border-b border-gray-300 dark:border-gray-700">
 				<div className="flex items-center gap-4">
 					<label className="text-sm font-medium text-gray-700 dark:text-gray-300">
@@ -91,8 +102,7 @@ export const MoviesWatched = () => {
 				</div>
 			</div>
 
-			{/* Movies List */}
-			<MovieLogList logs={logs} />
+			<MovieLogList logs={logs} isDropdownMenuVisible={isDropdownMenuVisible} />
 		</div>
 	);
 };

--- a/src/features/movie/components/MoviesWatched.unit.test.tsx
+++ b/src/features/movie/components/MoviesWatched.unit.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { HTTPError } from 'ky';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockGetLogs = vi.fn();
@@ -72,7 +73,23 @@ vi.mock('./MoviesWatchedLoading', () => ({
 
 import { MoviesWatched } from './MoviesWatched';
 
+function createHttpError(errorCodeName: string) {
+	const response = new Response(
+		JSON.stringify({
+			error_code_name: errorCodeName,
+			error_code: 403,
+			error_message: 'Forbidden',
+			error_description: 'Profile is not public',
+		}),
+		{ status: 403 }
+	);
+	const request = new Request('http://localhost/v1/logs/test');
+	return new HTTPError(response, request, {} as never);
+}
+
 describe('MoviesWatched', () => {
+	const handle = 'neo';
+
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockUseMovieLogDialogStore.mockReturnValue({ triggerCount: 0 });
@@ -82,14 +99,14 @@ describe('MoviesWatched', () => {
 		const currentYear = new Date().getFullYear();
 		mockGetLogs.mockResolvedValueOnce({ logs: [{ id: '1' }] });
 
-		render(<MoviesWatched />);
+		render(<MoviesWatched handle={handle} />);
 
 		expect(screen.getByTestId('movies-watched-loading')).toBeInTheDocument();
 
 		await waitFor(() =>
 			expect(screen.getByTestId('movie-log-list')).toHaveTextContent('1')
 		);
-		expect(mockGetLogs).toHaveBeenCalledWith({
+		expect(mockGetLogs).toHaveBeenCalledWith(handle, {
 			dateWatchedFrom: `${currentYear}-01-01`,
 			dateWatchedTo: `${currentYear}-12-31`,
 		});
@@ -97,24 +114,22 @@ describe('MoviesWatched', () => {
 
 	it('fetches all years when year filter changes to all', async () => {
 		const user = userEvent.setup();
-		mockGetLogs
-			.mockResolvedValueOnce({ logs: [] })
-			.mockResolvedValueOnce({ logs: [{ id: '2' }] });
+		mockGetLogs.mockResolvedValue({ logs: [] });
 
-		render(<MoviesWatched />);
+		render(<MoviesWatched handle={handle} />);
 		await waitFor(() =>
 			expect(screen.getByTestId('movie-log-list')).toBeInTheDocument()
 		);
 
 		await user.click(screen.getByTestId('select-all'));
 
-		await waitFor(() => expect(mockGetLogs).toHaveBeenLastCalledWith({}));
+		await waitFor(() => expect(mockGetLogs).toHaveBeenCalledWith(handle, {}));
 	});
 
 	it('renders fallback translated error for unknown thrown values', async () => {
 		mockGetLogs.mockRejectedValueOnce('unknown-error');
 
-		render(<MoviesWatched />);
+		render(<MoviesWatched handle={handle} />);
 
 		await waitFor(() =>
 			expect(screen.getByText('MoviesWatched.errorLoading')).toBeInTheDocument()
@@ -124,10 +139,20 @@ describe('MoviesWatched', () => {
 	it('renders Error message when request throws Error instance', async () => {
 		mockGetLogs.mockRejectedValueOnce(new Error('network-failed'));
 
-		render(<MoviesWatched />);
+		render(<MoviesWatched handle={handle} />);
 
 		await waitFor(() =>
 			expect(screen.getByText('network-failed')).toBeInTheDocument()
+		);
+	});
+
+	it('renders profile not public error when API returns PROFILE_NOT_PUBLIC', async () => {
+		mockGetLogs.mockRejectedValueOnce(createHttpError('PROFILE_NOT_PUBLIC'));
+
+		render(<MoviesWatched handle={handle} />);
+
+		await waitFor(() =>
+			expect(screen.getByText('ApiError.profileNotPublic')).toBeInTheDocument()
 		);
 	});
 });

--- a/src/features/profile/components/Profile.tsx
+++ b/src/features/profile/components/Profile.tsx
@@ -1,22 +1,43 @@
+import { Lock } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { Outlet } from 'react-router-dom';
-import type { UserResponse } from '@/features/auth/models/user-response';
+import type { UserProfileResponse } from '@/features/auth/models/user-profile-response';
 import { ProfileHeader, ProfileLayout, ProfileMenu } from '.';
 
 interface ProfileProps {
-	userInfo: UserResponse | null;
+	userInfo: UserProfileResponse | null;
+	isOwnProfile: boolean;
+	isPrivate: boolean;
 }
 
-export const Profile = ({ userInfo }: ProfileProps) => {
+export const Profile = ({
+	userInfo,
+	isOwnProfile,
+	isPrivate,
+}: ProfileProps) => {
+	const { t } = useTranslation();
+
 	return (
 		<ProfileLayout
 			sidebar={
 				<>
 					<ProfileHeader userInfo={userInfo} />
-					{userInfo?.handle && <ProfileMenu handle={userInfo.handle} />}
+					{userInfo?.handle && !isPrivate && (
+						<ProfileMenu handle={userInfo.handle} isOwnProfile={isOwnProfile} />
+					)}
 				</>
 			}
 		>
-			<Outlet />
+			{isPrivate && !isOwnProfile ? (
+				<div className="flex flex-col items-center justify-center py-20 text-gray-500 dark:text-gray-400">
+					<Lock className="w-12 h-12 mb-4 opacity-50" />
+					<p className="text-lg font-medium">
+						{t('ProfilePage.privateProfile')}
+					</p>
+				</div>
+			) : (
+				<Outlet />
+			)}
 		</ProfileLayout>
 	);
 };

--- a/src/features/profile/components/Profile.unit.test.tsx
+++ b/src/features/profile/components/Profile.unit.test.tsx
@@ -10,18 +10,21 @@ vi.mock('react-i18next', () => ({
 }));
 
 describe('Profile', () => {
+	const baseUserInfo = {
+		firstName: 'Neo',
+		lastName: 'Anderson',
+		handle: 'neo',
+		dateOfBirth: '1990-01-01',
+		profileVisibility: 'public' as const,
+	};
+
 	it('renders header, menu and outlet when user has handle', () => {
 		render(
 			<MemoryRouter>
 				<Profile
-					userInfo={{
-						id: '1',
-						firstName: 'Neo',
-						lastName: 'Anderson',
-						email: 'neo@matrix.dev',
-						handle: 'neo',
-						dateOfBirth: '1990-01-01',
-					}}
+					userInfo={baseUserInfo}
+					isOwnProfile={true}
+					isPrivate={false}
 				/>
 			</MemoryRouter>
 		);
@@ -36,20 +39,52 @@ describe('Profile', () => {
 			<MemoryRouter>
 				<Profile
 					userInfo={{
-						id: '2',
-						firstName: 'Trinity',
-						lastName: 'Unknown',
-						email: 'trinity@matrix.dev',
+						...baseUserInfo,
 						handle: '',
-						dateOfBirth: '1991-02-02',
-						bio: 'Operator',
 					}}
+					isOwnProfile={true}
+					isPrivate={false}
 				/>
 			</MemoryRouter>
 		);
 
-		expect(screen.getByText('Trinity Unknown')).toBeInTheDocument();
-		expect(screen.getByText('Operator')).toBeInTheDocument();
+		expect(screen.getByText('Neo Anderson')).toBeInTheDocument();
 		expect(screen.queryByText('ProfileMenu.overview')).not.toBeInTheDocument();
+	});
+
+	it('renders private profile message when isPrivate is true and not own profile', () => {
+		render(
+			<MemoryRouter>
+				<Profile
+					userInfo={{
+						...baseUserInfo,
+						profileVisibility: 'private',
+					}}
+					isOwnProfile={false}
+					isPrivate={true}
+				/>
+			</MemoryRouter>
+		);
+
+		expect(screen.getByText('ProfilePage.privateProfile')).toBeInTheDocument();
+	});
+
+	it('renders outlet when isPrivate is true but it is own profile', () => {
+		render(
+			<MemoryRouter>
+				<Profile
+					userInfo={{
+						...baseUserInfo,
+						profileVisibility: 'private',
+					}}
+					isOwnProfile={true}
+					isPrivate={false}
+				/>
+			</MemoryRouter>
+		);
+
+		expect(
+			screen.queryByText('ProfilePage.privateProfile')
+		).not.toBeInTheDocument();
 	});
 });

--- a/src/features/profile/components/ProfileHeader.tsx
+++ b/src/features/profile/components/ProfileHeader.tsx
@@ -1,9 +1,9 @@
 import { User } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import type { UserResponse } from '@/features/auth/models/user-response';
+import type { UserProfileResponse } from '@/features/auth/models/user-profile-response';
 
 interface ProfileHeaderProps {
-	userInfo: UserResponse | null;
+	userInfo: UserProfileResponse | null;
 }
 
 export const ProfileHeader = ({ userInfo }: ProfileHeaderProps) => {

--- a/src/features/profile/components/ProfileMenu.tsx
+++ b/src/features/profile/components/ProfileMenu.tsx
@@ -7,7 +7,6 @@ import {
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { NavLink } from 'react-router-dom';
-import { useAuthStore } from '@/features/auth/stores';
 
 interface ProfileMenuItem {
 	label: string;
@@ -18,12 +17,11 @@ interface ProfileMenuItem {
 
 interface ProfileMenuProps {
 	handle: string;
+	isOwnProfile: boolean;
 }
 
-export const ProfileMenu = ({ handle }: ProfileMenuProps) => {
+export const ProfileMenu = ({ handle, isOwnProfile }: ProfileMenuProps) => {
 	const { t } = useTranslation();
-	const userInfo = useAuthStore((state) => state.userInfo);
-	const isOwnProfile = userInfo?.handle === handle;
 
 	const menuItems: ProfileMenuItem[] = [
 		{
@@ -37,13 +35,13 @@ export const ProfileMenu = ({ handle }: ProfileMenuProps) => {
 			icon: Film,
 			path: `/profile/${handle}/movie-watched`,
 		},
-		{
-			label: t('ProfileMenu.stats'),
-			icon: BarChart3,
-			path: `/profile/${handle}/stats`,
-		},
 		...(isOwnProfile
 			? [
+					{
+						label: t('ProfileMenu.stats'),
+						icon: BarChart3,
+						path: `/profile/${handle}/stats`,
+					},
 					{
 						label: t('ProfileMenu.settings'),
 						icon: Settings,

--- a/src/features/profile/components/ProfileMenu.unit.test.tsx
+++ b/src/features/profile/components/ProfileMenu.unit.test.tsx
@@ -8,21 +8,6 @@ vi.mock('react-i18next', () => ({
 	}),
 }));
 
-const mockUserInfo = {
-	id: '1',
-	firstName: 'Neo',
-	lastName: 'Anderson',
-	email: 'neo@matrix.com',
-	handle: 'neo',
-	dateOfBirth: '1990-01-01',
-};
-
-vi.mock('@/features/auth/stores', () => ({
-	useAuthStore: (
-		selector: (state: { userInfo: typeof mockUserInfo | null }) => unknown
-	) => selector({ userInfo: mockUserInfo }),
-}));
-
 import { ProfileMenu } from './ProfileMenu';
 
 describe('ProfileMenu', () => {
@@ -30,45 +15,42 @@ describe('ProfileMenu', () => {
 		vi.clearAllMocks();
 	});
 
-	it('renders all profile navigation links for a handle', () => {
+	it('renders overview and movies watched for any profile', () => {
 		render(
 			<MemoryRouter initialEntries={['/profile/neo']}>
-				<ProfileMenu handle="neo" />
+				<ProfileMenu handle="neo" isOwnProfile={false} />
 			</MemoryRouter>
 		);
 
 		expect(screen.getByText('ProfileMenu.overview')).toBeInTheDocument();
 		expect(screen.getByText('ProfileMenu.moviesWatched')).toBeInTheDocument();
-		expect(screen.getByText('ProfileMenu.stats')).toBeInTheDocument();
-
-		const links = screen.getAllByRole('link');
-		expect(links[0]).toHaveAttribute('href', '/profile/neo');
-		expect(links[1]).toHaveAttribute('href', '/profile/neo/movie-watched');
-		expect(links[2]).toHaveAttribute('href', '/profile/neo/stats');
-		expect(links[0].className).toContain('bg-primary/10');
-		expect(links[1].className).toContain('text-gray-600');
 	});
 
-	it('shows Settings link when viewing own profile', () => {
+	it('shows Stats and Settings links when viewing own profile', () => {
 		render(
 			<MemoryRouter initialEntries={['/profile/neo']}>
-				<ProfileMenu handle="neo" />
+				<ProfileMenu handle="neo" isOwnProfile={true} />
 			</MemoryRouter>
 		);
 
+		expect(screen.getByText('ProfileMenu.stats')).toBeInTheDocument();
 		expect(screen.getByText('ProfileMenu.settings')).toBeInTheDocument();
+
 		const links = screen.getAllByRole('link');
+		expect(links).toHaveLength(4);
+		expect(links[2]).toHaveAttribute('href', '/profile/neo/stats');
 		expect(links[3]).toHaveAttribute('href', '/profile/neo/settings');
 	});
 
-	it('hides Settings link when viewing another user profile', () => {
+	it('hides Stats and Settings links when viewing another user profile', () => {
 		render(
 			<MemoryRouter initialEntries={['/profile/morpheus']}>
-				<ProfileMenu handle="morpheus" />
+				<ProfileMenu handle="morpheus" isOwnProfile={false} />
 			</MemoryRouter>
 		);
 
+		expect(screen.queryByText('ProfileMenu.stats')).not.toBeInTheDocument();
 		expect(screen.queryByText('ProfileMenu.settings')).not.toBeInTheDocument();
-		expect(screen.getAllByRole('link')).toHaveLength(3);
+		expect(screen.getAllByRole('link')).toHaveLength(2);
 	});
 });

--- a/src/features/profile/components/ProfileVisibilitySelect.tsx
+++ b/src/features/profile/components/ProfileVisibilitySelect.tsx
@@ -1,0 +1,38 @@
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from '@antoniobenincasa/ui';
+import { useTranslation } from 'react-i18next';
+import type { ProfileVisibility } from '@/lib/models';
+
+type ProfileVisibilitySelectProps = {
+	value: ProfileVisibility;
+	onChange: (value: ProfileVisibility) => void;
+};
+
+const VISIBLE_OPTIONS: ProfileVisibility[] = ['public', 'private'];
+
+export const ProfileVisibilitySelect = ({
+	value,
+	onChange,
+}: ProfileVisibilitySelectProps) => {
+	const { t } = useTranslation();
+
+	return (
+		<Select value={value} onValueChange={onChange}>
+			<SelectTrigger className="w-full">
+				<SelectValue />
+			</SelectTrigger>
+			<SelectContent>
+				{VISIBLE_OPTIONS.map((option) => (
+					<SelectItem key={option} value={option}>
+						{t(`ProfileVisibilitySelect.${option}`)}
+					</SelectItem>
+				))}
+			</SelectContent>
+		</Select>
+	);
+};

--- a/src/features/profile/components/ProfileVisibilitySelect.unit.test.tsx
+++ b/src/features/profile/components/ProfileVisibilitySelect.unit.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({
+		t: (key: string) => key,
+	}),
+}));
+
+vi.mock('@antoniobenincasa/ui', () => ({
+	Select: ({
+		value,
+		onValueChange,
+		children,
+	}: {
+		value: string;
+		onValueChange: (value: string) => void;
+		children: React.ReactNode;
+	}) => (
+		<div data-testid="select" data-value={value}>
+			<button
+				type="button"
+				data-testid="select-public"
+				onClick={() => onValueChange('public')}
+			>
+				public
+			</button>
+			<button
+				type="button"
+				data-testid="select-private"
+				onClick={() => onValueChange('private')}
+			>
+				private
+			</button>
+			<button
+				type="button"
+				data-testid="select-friends-only"
+				onClick={() => onValueChange('friends_only')}
+			>
+				friends_only
+			</button>
+			{children}
+		</div>
+	),
+	SelectTrigger: ({ children }: { children: React.ReactNode }) => (
+		<div>{children}</div>
+	),
+	SelectValue: () => <span />,
+	SelectContent: ({ children }: { children: React.ReactNode }) => (
+		<div>{children}</div>
+	),
+	SelectItem: ({
+		children,
+		value,
+	}: {
+		children: React.ReactNode;
+		value: string;
+	}) => <div data-testid={`select-item-${value}`}>{children}</div>,
+}));
+
+import { ProfileVisibilitySelect } from './ProfileVisibilitySelect';
+
+describe('ProfileVisibilitySelect', () => {
+	const mockOnChange = vi.fn();
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should render with the provided value', () => {
+		render(<ProfileVisibilitySelect value="private" onChange={mockOnChange} />);
+
+		expect(screen.getByTestId('select')).toHaveAttribute(
+			'data-value',
+			'private'
+		);
+	});
+
+	it('should render public and private options', () => {
+		render(<ProfileVisibilitySelect value="private" onChange={mockOnChange} />);
+
+		expect(screen.getByTestId('select-item-public')).toBeInTheDocument();
+		expect(screen.getByTestId('select-item-private')).toBeInTheDocument();
+	});
+
+	it('should not render friends_only option', () => {
+		render(<ProfileVisibilitySelect value="private" onChange={mockOnChange} />);
+
+		expect(
+			screen.queryByTestId('select-item-friends_only')
+		).not.toBeInTheDocument();
+	});
+
+	it('should call onChange with public when public is selected', async () => {
+		const user = userEvent.setup();
+		render(<ProfileVisibilitySelect value="private" onChange={mockOnChange} />);
+
+		await user.click(screen.getByTestId('select-public'));
+
+		expect(mockOnChange).toHaveBeenCalledWith('public');
+	});
+
+	it('should call onChange with private when private is selected', async () => {
+		const user = userEvent.setup();
+		render(<ProfileVisibilitySelect value="public" onChange={mockOnChange} />);
+
+		await user.click(screen.getByTestId('select-private'));
+
+		expect(mockOnChange).toHaveBeenCalledWith('private');
+	});
+});

--- a/src/features/profile/components/UpdateProfileForm.tsx
+++ b/src/features/profile/components/UpdateProfileForm.tsx
@@ -15,8 +15,11 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useAuthStore } from '@/features/auth/stores';
+import type { UpdateProfileRequest } from '@/features/profile/models';
+import type { ProfileVisibility } from '@/lib/models';
 import { type UpdateProfileSchema, updateProfileSchema } from '../schemas';
 import { useUserStore } from '../stores';
+import { ProfileVisibilitySelect } from './ProfileVisibilitySelect';
 
 export const UpdateProfileForm = () => {
 	const { t } = useTranslation();
@@ -43,6 +46,7 @@ export const UpdateProfileForm = () => {
 			lastName: userInfo?.lastName ?? '',
 			bio: userInfo?.bio ?? '',
 			dateOfBirth: userInfo?.dateOfBirth ?? '',
+			profileVisibility: userInfo?.profileVisibility ?? 'private',
 		},
 		mode: 'onBlur',
 	});
@@ -52,12 +56,13 @@ export const UpdateProfileForm = () => {
 	const handleSubmit = async (data: UpdateProfileSchema) => {
 		setLoading(true);
 
-		const payload: Partial<UpdateProfileSchema> = {};
+		const defaults = form.formState.defaultValues;
+		const payload: Partial<UpdateProfileRequest> = {};
 		for (const key of Object.keys(data) as (keyof UpdateProfileSchema)[]) {
-			const newValue = data[key] ?? '';
-			const currentValue = userInfo?.[key] ?? '';
-			if (newValue !== currentValue) {
-				payload[key] = newValue;
+			const newValue = data[key];
+			const currentValue = defaults?.[key];
+			if (newValue !== undefined && newValue !== currentValue) {
+				payload[key as keyof UpdateProfileRequest] = newValue as never;
 			}
 		}
 
@@ -67,13 +72,14 @@ export const UpdateProfileForm = () => {
 		}
 
 		try {
-			const updatedUser = await updateProfile(payload);
+			const updatedUser = await updateProfile(payload as UpdateProfileRequest);
 			updateUserInfo(updatedUser);
 			form.reset({
 				firstName: updatedUser.firstName ?? '',
 				lastName: updatedUser.lastName ?? '',
 				bio: updatedUser.bio ?? '',
 				dateOfBirth: updatedUser.dateOfBirth ?? '',
+				profileVisibility: updatedUser.profileVisibility,
 			});
 			notify({
 				variant: 'success',
@@ -171,6 +177,21 @@ export const UpdateProfileForm = () => {
 									placeholder={t('UpdateProfileForm.bioPlaceholder')}
 								/>
 							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+
+				<FormField
+					control={form.control}
+					name="profileVisibility"
+					render={({ field }) => (
+						<FormItem>
+							<FormLabel>{t('ProfileVisibilitySelect.label')}</FormLabel>
+							<ProfileVisibilitySelect
+								value={field.value ?? 'private'}
+								onChange={(value) => field.onChange(value as ProfileVisibility)}
+							/>
 							<FormMessage />
 						</FormItem>
 					)}

--- a/src/features/profile/components/UpdateProfileForm.unit.test.tsx
+++ b/src/features/profile/components/UpdateProfileForm.unit.test.tsx
@@ -35,6 +35,7 @@ const mockUserInfo = {
 	handle: 'janedoe',
 	dateOfBirth: '1990-01-15',
 	bio: 'My bio',
+	profileVisibility: 'private' as const,
 };
 
 const mockUpdateUserInfo = vi.fn();
@@ -45,6 +46,29 @@ vi.mock('@/features/auth/stores', () => ({
 			updateUserInfo: typeof mockUpdateUserInfo;
 		}) => unknown
 	) => selector({ userInfo: mockUserInfo, updateUserInfo: mockUpdateUserInfo }),
+}));
+
+vi.mock('./ProfileVisibilitySelect', () => ({
+	ProfileVisibilitySelect: ({
+		value,
+		onChange,
+	}: {
+		value: string;
+		onChange: (value: string) => void;
+	}) => (
+		<div data-testid="profile-visibility-select" data-value={value}>
+			<button
+				type="button"
+				data-testid="visibility-public"
+				onClick={() => onChange('public')}
+			/>
+			<button
+				type="button"
+				data-testid="visibility-private"
+				onClick={() => onChange('private')}
+			/>
+		</div>
+	),
 }));
 
 import { UpdateProfileForm } from './UpdateProfileForm';
@@ -333,6 +357,84 @@ describe('UpdateProfileForm', () => {
 					message: 'UpdateProfileForm.error',
 				});
 			});
+		});
+	});
+
+	describe('profile visibility', () => {
+		it('should render the profile visibility select with current value', () => {
+			render(<UpdateProfileForm />);
+
+			expect(screen.getByTestId('profile-visibility-select')).toHaveAttribute(
+				'data-value',
+				'private'
+			);
+		});
+
+		it('should send profileVisibility in payload when changed', async () => {
+			const updatedUser = {
+				...mockUserInfo,
+				profileVisibility: 'public' as const,
+			};
+			mockUpdateProfile.mockResolvedValueOnce(updatedUser);
+			render(<UpdateProfileForm />);
+
+			fireEvent.click(screen.getByTestId('visibility-public'));
+			fireEvent.click(
+				screen.getByRole('button', { name: 'UpdateProfileForm.submit' })
+			);
+
+			await waitFor(() => {
+				expect(mockUpdateProfile).toHaveBeenCalledWith({
+					profileVisibility: 'public',
+				});
+			});
+		});
+
+		it('should not send profileVisibility when unchanged', async () => {
+			render(<UpdateProfileForm />);
+
+			fireEvent.click(
+				screen.getByRole('button', { name: 'UpdateProfileForm.submit' })
+			);
+
+			await waitFor(() => {
+				expect(mockUpdateProfile).not.toHaveBeenCalled();
+			});
+		});
+
+		it('should enable submit button when only visibility is changed', () => {
+			render(<UpdateProfileForm />);
+
+			fireEvent.click(screen.getByTestId('visibility-public'));
+
+			expect(
+				screen.getByRole('button', { name: 'UpdateProfileForm.submit' })
+			).toBeEnabled();
+		});
+
+		it('should reset form with updated visibility after save', async () => {
+			const updatedUser = {
+				...mockUserInfo,
+				profileVisibility: 'public' as const,
+			};
+			mockUpdateProfile.mockResolvedValueOnce(updatedUser);
+			render(<UpdateProfileForm />);
+
+			fireEvent.click(screen.getByTestId('visibility-public'));
+			fireEvent.click(
+				screen.getByRole('button', { name: 'UpdateProfileForm.submit' })
+			);
+
+			await waitFor(() => {
+				expect(screen.getByTestId('profile-visibility-select')).toHaveAttribute(
+					'data-value',
+					'public'
+				);
+			});
+
+			expect(
+				screen.getByRole('button', { name: 'UpdateProfileForm.submit' })
+			).toBeDisabled();
 		});
 	});
 });

--- a/src/features/profile/models/update-profile-request.ts
+++ b/src/features/profile/models/update-profile-request.ts
@@ -1,6 +1,9 @@
+import type { ProfileVisibility } from '@/lib/models';
+
 export type UpdateProfileRequest = {
 	firstName?: string;
 	lastName?: string;
 	bio?: string;
 	dateOfBirth?: string;
+	profileVisibility?: ProfileVisibility;
 };

--- a/src/features/profile/pages/ProfileMoviesWatchedPage.tsx
+++ b/src/features/profile/pages/ProfileMoviesWatchedPage.tsx
@@ -1,13 +1,23 @@
 import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
+import { useAuthStore } from '@/features/auth/stores';
 import { MoviesWatched } from '@/features/movie/components/MoviesWatched';
 
 const ProfileMoviesWatchedPage = () => {
 	const { t } = useTranslation();
+	const { handle } = useParams<{ handle: string }>();
+	const { userInfo } = useAuthStore();
+
+	if (!handle) {
+		return null;
+	}
+
+	const isOwnProfile = userInfo?.handle === handle;
 
 	return (
 		<>
 			<title>{t('ProfileMoviesWatchedPage.pageTitle')}</title>
-			<MoviesWatched />
+			<MoviesWatched handle={handle} isDropdownMenuVisible={isOwnProfile} />
 		</>
 	);
 };

--- a/src/features/profile/pages/ProfileMoviesWatchedPage.unit.test.tsx
+++ b/src/features/profile/pages/ProfileMoviesWatchedPage.unit.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('react-i18next', () => ({
@@ -8,10 +9,25 @@ vi.mock('react-i18next', () => ({
 }));
 
 vi.mock('@/features/movie/components/MoviesWatched', () => ({
-	MoviesWatched: () => <div data-testid="movies-watched">Movies Watched</div>,
+	MoviesWatched: ({ handle }: { handle: string }) => (
+		<div data-testid="movies-watched">{handle}</div>
+	),
 }));
 
 import ProfileMoviesWatchedPage from './ProfileMoviesWatchedPage';
+
+function renderWithRouter(handle: string) {
+	return render(
+		<MemoryRouter initialEntries={[`/profile/${handle}/movie-watched`]}>
+			<Routes>
+				<Route
+					path="/profile/:handle/movie-watched"
+					element={<ProfileMoviesWatchedPage />}
+				/>
+			</Routes>
+		</MemoryRouter>
+	);
+}
 
 describe('ProfileMoviesWatchedPage', () => {
 	beforeEach(() => {
@@ -19,7 +35,7 @@ describe('ProfileMoviesWatchedPage', () => {
 	});
 
 	it('should render the page title', () => {
-		render(<ProfileMoviesWatchedPage />);
+		renderWithRouter('neo');
 
 		const titleElement = document.querySelector('title');
 		expect(titleElement).toBeInTheDocument();
@@ -28,9 +44,10 @@ describe('ProfileMoviesWatchedPage', () => {
 		);
 	});
 
-	it('should render the MoviesWatched component', () => {
-		render(<ProfileMoviesWatchedPage />);
+	it('should render the MoviesWatched component with handle', () => {
+		renderWithRouter('neo');
 
 		expect(screen.getByTestId('movies-watched')).toBeInTheDocument();
+		expect(screen.getByTestId('movies-watched')).toHaveTextContent('neo');
 	});
 });

--- a/src/features/profile/pages/ProfileNotFoundPage.tsx
+++ b/src/features/profile/pages/ProfileNotFoundPage.tsx
@@ -1,0 +1,25 @@
+import { Button } from '@antoniobenincasa/ui';
+import { UserX } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+
+const ProfileNotFoundPage = () => {
+	const { t } = useTranslation();
+
+	return (
+		<div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 text-center">
+			<UserX className="size-16 text-gray-400 dark:text-gray-500" />
+			<h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
+				{t('ProfileNotFoundPage.title')}
+			</h1>
+			<p className="text-gray-500 dark:text-gray-400">
+				{t('ProfileNotFoundPage.description')}
+			</p>
+			<Button asChild variant="default">
+				<Link to="/">{t('ProfileNotFoundPage.goHome')}</Link>
+			</Button>
+		</div>
+	);
+};
+
+export default ProfileNotFoundPage;

--- a/src/features/profile/pages/ProfileNotFoundPage.unit.test.tsx
+++ b/src/features/profile/pages/ProfileNotFoundPage.unit.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({
+		t: (key: string) => key,
+	}),
+}));
+
+import ProfileNotFoundPage from './ProfileNotFoundPage';
+
+function renderWithRouter() {
+	return render(
+		<MemoryRouter initialEntries={['/profile/unknown']}>
+			<Routes>
+				<Route path="/profile/:handle" element={<ProfileNotFoundPage />} />
+				<Route path="/" element={<div data-testid="home">Home</div>} />
+			</Routes>
+		</MemoryRouter>
+	);
+}
+
+describe('ProfileNotFoundPage', () => {
+	it('should render the title', () => {
+		renderWithRouter();
+
+		expect(screen.getByText('ProfileNotFoundPage.title')).toBeInTheDocument();
+	});
+
+	it('should render the description', () => {
+		renderWithRouter();
+
+		expect(
+			screen.getByText('ProfileNotFoundPage.description')
+		).toBeInTheDocument();
+	});
+
+	it('should render a go home link pointing to /', () => {
+		renderWithRouter();
+
+		const link = screen.getByText('ProfileNotFoundPage.goHome');
+		expect(link).toBeInTheDocument();
+		expect(link.closest('a')).toHaveAttribute('href', '/');
+	});
+});

--- a/src/features/profile/pages/ProfilePage.tsx
+++ b/src/features/profile/pages/ProfilePage.tsx
@@ -1,14 +1,70 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import type { UserProfileResponse } from '@/features/auth/models/user-profile-response';
+import { getProfile } from '@/features/auth/repositories/user-repository';
 import { useAuthStore } from '@/features/auth/stores';
+import { extractApiError } from '@/lib/api/api-error';
 import { Profile, ProfileLoading } from '../components';
+import ProfileNotFoundPage from './ProfileNotFoundPage';
 
 const ProfilePage = () => {
+	const { handle } = useParams<{ handle: string }>();
 	const { userInfo, isUserInfoLoading } = useAuthStore();
+	const [profileData, setProfileData] = useState<UserProfileResponse | null>(
+		null
+	);
+	const [isProfileLoading, setIsProfileLoading] = useState(false);
+	const [notFound, setNotFound] = useState(false);
 
-	if (isUserInfoLoading) {
+	const isOwnProfile = userInfo?.handle === handle;
+
+	useEffect(() => {
+		if (!handle || isOwnProfile || isUserInfoLoading) return;
+
+		setIsProfileLoading(true);
+		setNotFound(false);
+		getProfile(handle)
+			.then(setProfileData)
+			.catch(async (err) => {
+				const apiError = await extractApiError(err);
+				if (apiError?.error_code_name === 'USER_NOT_FOUND') {
+					setNotFound(true);
+				} else {
+					setProfileData(null);
+				}
+			})
+			.finally(() => setIsProfileLoading(false));
+	}, [handle, isOwnProfile, isUserInfoLoading]);
+
+	if (isUserInfoLoading || isProfileLoading) {
 		return <ProfileLoading />;
 	}
 
-	return <Profile userInfo={userInfo} />;
+	if (!handle) {
+		return null;
+	}
+
+	if (notFound) {
+		return <ProfileNotFoundPage />;
+	}
+
+	if (isOwnProfile) {
+		return (
+			<Profile userInfo={userInfo} isOwnProfile={true} isPrivate={false} />
+		);
+	}
+
+	if (!profileData) {
+		return null;
+	}
+
+	return (
+		<Profile
+			userInfo={profileData}
+			isOwnProfile={false}
+			isPrivate={profileData.profileVisibility !== 'public'}
+		/>
+	);
 };
 
 export default ProfilePage;

--- a/src/features/profile/pages/ProfilePage.unit.test.tsx
+++ b/src/features/profile/pages/ProfilePage.unit.test.tsx
@@ -1,61 +1,223 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import ProfilePage from './ProfilePage';
 
 const mockUseAuthStore = vi.fn();
+const mockGetProfile = vi.fn();
+const mockExtractApiError = vi.fn();
 
 vi.mock('@/features/auth/stores', () => ({
 	useAuthStore: () => mockUseAuthStore(),
 }));
 
+vi.mock('@/features/auth/repositories/user-repository', () => ({
+	getProfile: (...args: unknown[]) => mockGetProfile(...args),
+}));
+
+vi.mock('@/lib/api/api-error', () => ({
+	extractApiError: (...args: unknown[]) => mockExtractApiError(...args),
+}));
+
 vi.mock('../components', () => ({
-	Profile: ({ userInfo }: { userInfo: unknown }) => (
-		<div data-testid="profile">{JSON.stringify(userInfo)}</div>
+	Profile: ({
+		userInfo,
+		isOwnProfile,
+		isPrivate,
+	}: {
+		userInfo: unknown;
+		isOwnProfile: boolean;
+		isPrivate: boolean;
+	}) => (
+		<div data-testid="profile">
+			{JSON.stringify({ userInfo, isOwnProfile, isPrivate })}
+		</div>
 	),
 	ProfileLoading: () => <div data-testid="profile-loading">Loading</div>,
 }));
 
-import ProfilePage from './ProfilePage';
+function renderWithRouter(handle: string) {
+	return render(
+		<MemoryRouter initialEntries={[`/profile/${handle}`]}>
+			<Routes>
+				<Route path="/profile/:handle" element={<ProfilePage />} />
+			</Routes>
+		</MemoryRouter>
+	);
+}
 
 describe('ProfilePage', () => {
+	const ownUserInfo = {
+		firstName: 'Neo',
+		lastName: 'Anderson',
+		email: 'neo@matrix.dev',
+		handle: 'neo',
+		dateOfBirth: '1990-01-01',
+		profileVisibility: 'private' as const,
+	};
+
 	beforeEach(() => {
-		vi.clearAllMocks();
+		vi.resetAllMocks();
 	});
 
-	it('should render ProfileLoading when user info is loading', () => {
+	it('renders ProfileLoading when user info is loading', async () => {
 		mockUseAuthStore.mockReturnValue({
 			userInfo: null,
 			isUserInfoLoading: true,
 		});
+		mockGetProfile.mockResolvedValueOnce({});
 
-		render(<ProfilePage />);
+		await act(() => {
+			renderWithRouter('neo');
+		});
 
 		expect(screen.getByTestId('profile-loading')).toBeInTheDocument();
 		expect(screen.queryByTestId('profile')).not.toBeInTheDocument();
 	});
 
-	it('should render Profile when user info is loaded', () => {
+	it('renders own profile using auth store data', async () => {
 		mockUseAuthStore.mockReturnValue({
-			userInfo: { name: 'John' },
+			userInfo: ownUserInfo,
 			isUserInfoLoading: false,
 		});
 
-		render(<ProfilePage />);
+		await act(() => {
+			renderWithRouter('neo');
+		});
 
 		expect(screen.getByTestId('profile')).toBeInTheDocument();
+		expect(screen.getByTestId('profile')).toHaveTextContent(
+			JSON.stringify({
+				userInfo: ownUserInfo,
+				isOwnProfile: true,
+				isPrivate: false,
+			})
+		);
+	});
+
+	it('fetches and renders other user profile', async () => {
+		const otherProfile = {
+			firstName: 'Morpheus',
+			lastName: 'Leader',
+			handle: 'morpheus',
+			dateOfBirth: '',
+			profileVisibility: 'public',
+		};
+
+		mockUseAuthStore.mockReturnValue({
+			userInfo: ownUserInfo,
+			isUserInfoLoading: false,
+		});
+		mockGetProfile.mockResolvedValueOnce(otherProfile);
+
+		renderWithRouter('morpheus');
+
+		await waitFor(() =>
+			expect(screen.getByTestId('profile')).toBeInTheDocument()
+		);
+
+		expect(mockGetProfile).toHaveBeenCalledWith('morpheus');
+		expect(screen.getByTestId('profile')).toHaveTextContent(
+			JSON.stringify({
+				userInfo: otherProfile,
+				isOwnProfile: false,
+				isPrivate: false,
+			})
+		);
+	});
+
+	it('fetches and renders other user private profile', async () => {
+		const privateProfile = {
+			firstName: 'Trinity',
+			lastName: 'Hacker',
+			handle: 'trinity',
+			dateOfBirth: '1988-08-08',
+			profileVisibility: 'private',
+		};
+
+		mockUseAuthStore.mockReturnValue({
+			userInfo: ownUserInfo,
+			isUserInfoLoading: false,
+		});
+		mockGetProfile.mockResolvedValueOnce(privateProfile);
+
+		renderWithRouter('trinity');
+
+		await waitFor(() =>
+			expect(screen.getByTestId('profile')).toBeInTheDocument()
+		);
+
+		expect(screen.getByTestId('profile')).toHaveTextContent(
+			JSON.stringify({
+				userInfo: privateProfile,
+				isOwnProfile: false,
+				isPrivate: true,
+			})
+		);
+	});
+
+	it('renders nothing when profile fetch fails with non-USER_NOT_FOUND error', async () => {
+		mockUseAuthStore.mockReturnValue({
+			userInfo: ownUserInfo,
+			isUserInfoLoading: false,
+		});
+		mockGetProfile.mockRejectedValueOnce(new Error('Server error'));
+		mockExtractApiError.mockResolvedValueOnce(null);
+
+		renderWithRouter('unknown');
+
+		await waitFor(() => expect(mockGetProfile).toHaveBeenCalledWith('unknown'));
+
+		expect(screen.queryByTestId('profile')).not.toBeInTheDocument();
+		expect(screen.queryByTestId('profile-loading')).not.toBeInTheDocument();
+		expect(
+			screen.queryByText('ProfileNotFoundPage.title')
+		).not.toBeInTheDocument();
+	});
+
+	it('renders ProfileNotFoundPage when API returns USER_NOT_FOUND', async () => {
+		mockUseAuthStore.mockReturnValue({
+			userInfo: ownUserInfo,
+			isUserInfoLoading: false,
+		});
+		mockGetProfile.mockRejectedValueOnce(new Error('Not found'));
+		mockExtractApiError.mockResolvedValueOnce({
+			error_code_name: 'USER_NOT_FOUND',
+			error_code: 404,
+			error_message: 'User not found',
+			error_description: 'User not found',
+		});
+
+		renderWithRouter('unknown');
+
+		await waitFor(() =>
+			expect(screen.getByText('ProfileNotFoundPage.title')).toBeInTheDocument()
+		);
+
+		expect(screen.queryByTestId('profile')).not.toBeInTheDocument();
 		expect(screen.queryByTestId('profile-loading')).not.toBeInTheDocument();
 	});
 
-	it('should pass userInfo to Profile component', () => {
-		const userInfo = { name: 'John', email: 'john@test.com' };
+	it('renders nothing when API returns a different error code', async () => {
 		mockUseAuthStore.mockReturnValue({
-			userInfo,
+			userInfo: ownUserInfo,
 			isUserInfoLoading: false,
 		});
+		mockGetProfile.mockRejectedValueOnce(new Error('Forbidden'));
+		mockExtractApiError.mockResolvedValueOnce({
+			error_code_name: 'SOME_OTHER_ERROR',
+			error_code: 500,
+			error_message: 'Internal error',
+			error_description: 'Internal error',
+		});
 
-		render(<ProfilePage />);
+		renderWithRouter('unknown');
 
-		expect(screen.getByTestId('profile')).toHaveTextContent(
-			JSON.stringify(userInfo)
-		);
+		await waitFor(() => expect(mockGetProfile).toHaveBeenCalledWith('unknown'));
+
+		expect(screen.queryByTestId('profile')).not.toBeInTheDocument();
+		expect(
+			screen.queryByText('ProfileNotFoundPage.title')
+		).not.toBeInTheDocument();
 	});
 });

--- a/src/features/profile/schemas/update-profile.schema.ts
+++ b/src/features/profile/schemas/update-profile.schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { PROFILE_VISIBILITY_VALUES } from '@/lib/models';
 
 export const updateProfileSchema = (messages: {
 	firstNameRequired: string;
@@ -61,6 +62,7 @@ export const updateProfileSchema = (messages: {
 						});
 					}
 				}),
+			profileVisibility: z.enum(PROFILE_VISIBILITY_VALUES).optional(),
 		})
 		.strict();
 

--- a/src/features/stats/models/stats-filter-preset.ts
+++ b/src/features/stats/models/stats-filter-preset.ts
@@ -1,21 +1,16 @@
-export type StatsFilterPreset =
-	| 'allTime'
-	| 'thisYear'
-	| 'lastYear'
-	| 'last5Years'
-	| 'custom';
+const currentYear = new Date().getFullYear();
+
+export const STATS_FILTER_PRESETS = [
+	{ key: 'allTime', from: undefined, to: undefined },
+	{ key: 'thisYear', from: currentYear, to: currentYear },
+	{ key: 'lastYear', from: currentYear - 1, to: currentYear - 1 },
+	{ key: 'last5Years', from: currentYear - 5, to: currentYear },
+] as const;
+
+export type StatsFilterPreset = (typeof STATS_FILTER_PRESETS)[number]['key'];
 
 export interface StatsFilterPresetConfig {
 	key: StatsFilterPreset;
 	from: number | undefined;
 	to: number | undefined;
 }
-
-const currentYear = new Date().getFullYear();
-
-export const STATS_FILTER_PRESETS: StatsFilterPresetConfig[] = [
-	{ key: 'allTime', from: undefined, to: undefined },
-	{ key: 'thisYear', from: currentYear, to: currentYear },
-	{ key: 'lastYear', from: currentYear - 1, to: currentYear - 1 },
-	{ key: 'last5Years', from: currentYear - 5, to: currentYear },
-];

--- a/src/features/stats/stores/useStatsStore.ts
+++ b/src/features/stats/stores/useStatsStore.ts
@@ -15,7 +15,7 @@ interface StatsStore {
 	appliedFilters: GetStatsParams | null;
 	canApplyFilters(): boolean;
 	isAllTime(): boolean;
-	activePreset(): StatsFilterPreset;
+	activePreset(): StatsFilterPreset | 'custom';
 	setAllTime(value: boolean): void;
 	setYearFrom: (yearFrom: number | null) => void;
 	setYearTo: (yearTo: number | null) => void;
@@ -57,7 +57,7 @@ export const useStatsStore = create<StatsStore>((set, get) => ({
 		return !filters?.yearFrom && !filters?.yearTo;
 	},
 
-	activePreset(): StatsFilterPreset {
+	activePreset(): StatsFilterPreset | 'custom' {
 		const { filters } = get();
 		const preset = STATS_FILTER_PRESETS.find(
 			(p) => p.from === filters?.yearFrom && p.to === filters?.yearTo

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -285,6 +285,20 @@
 	},
 	"ApiError": {
 		"invalidCurrentPassword": "Current password is incorrect",
-		"samePassword": "New password must be different from the current password"
+		"samePassword": "New password must be different from the current password",
+		"profileNotPublic": "This profile is not public"
+	},
+	"ProfilePage": {
+		"privateProfile": "This profile is private"
+	},
+	"ProfileNotFoundPage": {
+		"title": "User not found",
+		"description": "The user you're looking for doesn't exist.",
+		"goHome": "Go home"
+	},
+	"ProfileVisibilitySelect": {
+		"label": "Profile Visibility",
+		"public": "Public",
+		"private": "Private"
 	}
 }

--- a/src/lib/locales/fr.json
+++ b/src/lib/locales/fr.json
@@ -281,6 +281,20 @@
 	},
 	"ApiError": {
 		"invalidCurrentPassword": "Le mot de passe actuel est incorrect",
-		"samePassword": "Le nouveau mot de passe doit être différent du mot de passe actuel"
+		"samePassword": "Le nouveau mot de passe doit être différent du mot de passe actuel",
+		"profileNotPublic": "Ce profil n'est pas public"
+	},
+	"ProfilePage": {
+		"privateProfile": "Ce profil est privé"
+	},
+	"ProfileNotFoundPage": {
+		"title": "Utilisateur introuvable",
+		"description": "L'utilisateur que vous recherchez n'existe pas.",
+		"goHome": "Retour à l'accueil"
+	},
+	"ProfileVisibilitySelect": {
+		"label": "Visibilité du profil",
+		"public": "Public",
+		"private": "Privé"
 	}
 }

--- a/src/lib/locales/it.json
+++ b/src/lib/locales/it.json
@@ -281,6 +281,20 @@
 	},
 	"ApiError": {
 		"invalidCurrentPassword": "La password attuale non è corretta",
-		"samePassword": "La nuova password deve essere diversa dalla password attuale"
+		"samePassword": "La nuova password deve essere diversa dalla password attuale",
+		"profileNotPublic": "Questo profilo non è pubblico"
+	},
+	"ProfilePage": {
+		"privateProfile": "Questo profilo è privato"
+	},
+	"ProfileNotFoundPage": {
+		"title": "Utente non trovato",
+		"description": "L'utente che stai cercando non esiste.",
+		"goHome": "Vai alla home"
+	},
+	"ProfileVisibilitySelect": {
+		"label": "Visibilità del profilo",
+		"public": "Pubblico",
+		"private": "Privato"
 	}
 }

--- a/src/lib/models/index.ts
+++ b/src/lib/models/index.ts
@@ -1,1 +1,3 @@
+export type { ProfileVisibility } from './profile-visibility';
+export { PROFILE_VISIBILITY_VALUES } from './profile-visibility';
 export type { Theme } from './theme';

--- a/src/lib/models/profile-visibility.ts
+++ b/src/lib/models/profile-visibility.ts
@@ -1,0 +1,7 @@
+export const PROFILE_VISIBILITY_VALUES = [
+	'public',
+	'friends_only',
+	'private',
+] as const;
+
+export type ProfileVisibility = (typeof PROFILE_VISIBILITY_VALUES)[number];


### PR DESCRIPTION
## Summary

Implements GitHub issue #47 — adds `profileVisibility` field to user settings, registration, and public profile viewing.

### Key features:
- **Profile visibility** (`public`/`private`/`friends_only`) stored on user, configurable during registration and from settings
- **Public profile page** at `/profile/:handle` — own profile uses auth store data, other users fetched via `GET /v1/users/{handle}/profile`
- **Handle-based log fetching** — `GET /v1/logs/{handle}` replaces the previous endpoint
- **Private profile handling** — lock icon + message shown for non-public profiles; `PROFILE_NOT_PUBLIC` (403) handled gracefully
- **User not found page** — `USER_NOT_FOUND` (404) renders a full-page component with "Go home" button
- **OwnerRoute guard** — settings route protected, redirects non-owners to `/profile/{handle}`
- **ProfileVisibilitySelect** — shared reusable component with its own i18n namespace (`ProfileVisibilitySelect.*`)

### Related
- Closes #47
- Backend: https://github.com/benincasantonio/cinelog_server/issues/121

## Commits

| Commit | Description |
|---|---|
| `67924af` | User settings page with profile editing and password change |
| `45cda37` | Profile visibility feature in settings form |
| `5b8cd17` | Public profile viewing and handle-based log fetching |
| `46d2a5c` | Profile visibility selection in registration and update forms |
| `30de475` | ProfileNotFoundPage for USER_NOT_FOUND (404) |
| `f21ac67` | Profile visibility toggle in MoviesWatched and MovieLog |
| `5800108` | Numeric rating badge while selecting stars |
| `9e62ef1` | i18n for rating display |

## Test coverage

- 722 tests passing (76 test files)
- New tests: `ProfileVisibilitySelect`, `ProfileNotFoundPage`, `RegistrationForm` (profileVisibility), `ProfilePage` (not-found, private), `MoviesWatched` (PROFILE_NOT_PUBLIC), `OwnerRoute`