### PR TITLE
feat(movie): add delete movie log functionality with confirmation dialog

### DIFF
--- a/src/features/logs/components/CreateMovieLogButton.css
+++ b/src/features/logs/components/CreateMovieLogButton.css
@@ -1,0 +1,10 @@
+.create-movie-log-button {
+	display: none;
+	justify-items: center;
+}
+
+@media (min-width: 768px) {
+	.create-movie-log-button {
+		display: inline-flex;
+	}
+}

--- a/src/features/logs/components/DeleteMovieLogDialog.tsx
+++ b/src/features/logs/components/DeleteMovieLogDialog.tsx
@@ -1,0 +1,68 @@
+import {
+	Button,
+	Dialog,
+	DialogClose,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from '@antoniobenincasa/ui';
+import { useTranslation } from 'react-i18next';
+import { useMovieLogStore } from '../stores/movieLogStore';
+
+interface DeleteMovieLogDialogProps {
+	isOpen: boolean;
+	onClose: () => void;
+	onConfirm: () => Promise<void>;
+}
+
+export const DeleteMovieLogDialog = ({
+	isOpen,
+	onClose,
+	onConfirm,
+}: DeleteMovieLogDialogProps) => {
+	const { t } = useTranslation();
+	const isDeleteMovieLogLoading = useMovieLogStore(
+		(state) => state.isDeleteMovieLogLoading
+	);
+
+	const onOpenChange = (open: boolean) => {
+		if (!open) {
+			onClose();
+		}
+	};
+
+	return (
+		<Dialog open={isOpen} onOpenChange={onOpenChange}>
+			<DialogContent
+				showCloseButton
+				className="w-full max-w-106.25 sm:max-w-lg"
+			>
+				<DialogHeader>
+					<DialogTitle>{t('DeleteMovieLogDialog.title')}</DialogTitle>
+					<DialogDescription>
+						{t('DeleteMovieLogDialog.description')}
+					</DialogDescription>
+				</DialogHeader>
+
+				<DialogFooter>
+					<DialogClose asChild>
+						<Button variant="secondary">
+							{t('DeleteMovieLogDialog.cancel')}
+						</Button>
+					</DialogClose>
+					<Button
+						variant="destructive"
+						onClick={onConfirm}
+						disabled={isDeleteMovieLogLoading}
+					>
+						{isDeleteMovieLogLoading
+							? t('DeleteMovieLogDialog.confirm')
+							: t('DeleteMovieLogDialog.confirm')}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+};

--- a/src/features/logs/components/index.ts
+++ b/src/features/logs/components/index.ts
@@ -1,2 +1,3 @@
 export * from './CreateMovieLogButton';
+export * from './DeleteMovieLogDialog';
 export * from './MovieLogDialog';

--- a/src/features/logs/repositories/log-repository.ts
+++ b/src/features/logs/repositories/log-repository.ts
@@ -54,3 +54,7 @@ export const updateLog = async (
 		})
 		.json();
 };
+
+export const deleteLog = async (logId: string): Promise<void> => {
+	await apiClient.delete(`v1/logs/${logId}`);
+};

--- a/src/features/logs/stores/index.ts
+++ b/src/features/logs/stores/index.ts
@@ -1,1 +1,2 @@
 export * from './movieLogDialogStore';
+export * from './movieLogStore';

--- a/src/features/logs/stores/movieLogStore.ts
+++ b/src/features/logs/stores/movieLogStore.ts
@@ -1,17 +1,24 @@
 import { create } from 'zustand';
 import type { LogCreateRequest, LogUpdateRequest } from '../models';
-import { createLog, updateLog } from '../repositories';
+import {
+	createLog,
+	deleteLog as deleteLogRepository,
+	updateLog,
+} from '../repositories';
 
 interface MovieLogStore {
 	isLoading: boolean;
+	isDeleteMovieLogLoading: boolean;
 	error: string | null;
 	createLog: (data: LogCreateRequest) => Promise<void>;
 	updateLog: (movieId: string, data: LogUpdateRequest) => Promise<void>;
+	deleteLog: (logId: string) => Promise<void>;
 	clearError: () => void;
 }
 
 export const useMovieLogStore = create<MovieLogStore>((set) => ({
 	isLoading: false,
+	isDeleteMovieLogLoading: false,
 	error: null,
 	async createLog(data: LogCreateRequest) {
 		set({
@@ -49,6 +56,26 @@ export const useMovieLogStore = create<MovieLogStore>((set) => ({
 		} finally {
 			set({
 				isLoading: false,
+			});
+		}
+	},
+	async deleteLog(logId: string) {
+		set({
+			isDeleteMovieLogLoading: true,
+			error: null,
+		});
+
+		try {
+			await deleteLogRepository(logId);
+		} catch (error) {
+			const message =
+				error instanceof Error ? error.message : 'Failed to delete movie log';
+			set({ error: message });
+			console.error(error);
+			throw error;
+		} finally {
+			set({
+				isDeleteMovieLogLoading: false,
 			});
 		}
 	},

--- a/src/features/logs/stores/movieLogStore.unit.test.ts
+++ b/src/features/logs/stores/movieLogStore.unit.test.ts
@@ -5,13 +5,15 @@ import { useMovieLogStore } from './movieLogStore';
 // Mock the repository functions
 vi.mock('../repositories', () => ({
 	createLog: vi.fn(),
+	deleteLog: vi.fn(),
 	updateLog: vi.fn(),
 }));
 
 import type { LogCreateResponse } from '../models';
-import { createLog, updateLog } from '../repositories';
+import { createLog, deleteLog, updateLog } from '../repositories';
 
 const mockCreateLog = vi.mocked(createLog);
+const mockDeleteLog = vi.mocked(deleteLog);
 const mockUpdateLog = vi.mocked(updateLog);
 
 describe('useMovieLogStore', () => {
@@ -42,6 +44,11 @@ describe('useMovieLogStore', () => {
 		it('should have error as null initially', () => {
 			const { result } = renderHook(() => useMovieLogStore());
 			expect(result.current.error).toBeNull();
+		});
+
+		it('should have isDeleteMovieLogLoading as false initially', () => {
+			const { result } = renderHook(() => useMovieLogStore());
+			expect(result.current.isDeleteMovieLogLoading).toBe(false);
 		});
 	});
 
@@ -212,6 +219,84 @@ describe('useMovieLogStore', () => {
 			});
 
 			expect(result.current.error).toBe('Failed to update movie log');
+		});
+	});
+
+	describe('deleteLog', () => {
+		const logId = 'log-1';
+
+		it('should set isDeleteMovieLogLoading to true while deleting log', async () => {
+			mockDeleteLog.mockImplementation(
+				() => new Promise((resolve) => setTimeout(resolve, 100))
+			);
+
+			const { result } = renderHook(() => useMovieLogStore());
+
+			act(() => {
+				result.current.deleteLog(logId);
+			});
+
+			expect(result.current.isDeleteMovieLogLoading).toBe(true);
+		});
+
+		it('should set isDeleteMovieLogLoading to false after successful delete', async () => {
+			mockDeleteLog.mockResolvedValueOnce(undefined);
+
+			const { result } = renderHook(() => useMovieLogStore());
+
+			await act(async () => {
+				await result.current.deleteLog(logId);
+			});
+
+			expect(result.current.isDeleteMovieLogLoading).toBe(false);
+			expect(result.current.error).toBeNull();
+		});
+
+		it('should set error on failed delete', async () => {
+			const errorMessage = 'Delete failed';
+			mockDeleteLog.mockRejectedValueOnce(new Error(errorMessage));
+
+			const { result } = renderHook(() => useMovieLogStore());
+
+			await act(async () => {
+				try {
+					await result.current.deleteLog(logId);
+				} catch {
+					// Expected to throw
+				}
+			});
+
+			expect(result.current.isDeleteMovieLogLoading).toBe(false);
+			expect(result.current.error).toBe(errorMessage);
+		});
+
+		it('should throw error on failed delete', async () => {
+			const errorMessage = 'Delete failed';
+			mockDeleteLog.mockRejectedValueOnce(new Error(errorMessage));
+
+			const { result } = renderHook(() => useMovieLogStore());
+
+			await expect(
+				act(async () => {
+					await result.current.deleteLog(logId);
+				})
+			).rejects.toThrow(errorMessage);
+		});
+
+		it('should set default error message when error is not an Error instance', async () => {
+			mockDeleteLog.mockRejectedValueOnce('Unknown error');
+
+			const { result } = renderHook(() => useMovieLogStore());
+
+			await act(async () => {
+				try {
+					await result.current.deleteLog(logId);
+				} catch {
+					// Expected to throw
+				}
+			});
+
+			expect(result.current.error).toBe('Failed to delete movie log');
 		});
 	});
 

--- a/src/features/movie/components/MovieLogItem.integration.test.tsx
+++ b/src/features/movie/components/MovieLogItem.integration.test.tsx
@@ -5,41 +5,19 @@ import type { LogListItem } from '@/features/logs/models';
 import { TestWrapper } from './MovieLogItem.test-setup';
 import { createMockLog } from './MovieLogItem.test-utils';
 
-// Mock useMovieLogDialogStore
-vi.mock('@/features/logs/stores', () => ({
-	useMovieLogDialogStore: () => ({
-		open: vi.fn(),
-	}),
+// Mock only at the HTTP boundary (repository layer)
+vi.mock('@/features/logs/repositories', () => ({
+	createLog: vi.fn(),
+	deleteLog: vi.fn(),
+	getLogs: vi.fn(),
+	updateLog: vi.fn(),
 }));
 
-// Mock react-i18next
+// Mock react-i18next (requires provider setup otherwise)
 vi.mock('react-i18next', () => ({
 	useTranslation: () => ({
 		t: (key: string) => key,
 	}),
-}));
-
-// Mock MovieVote component
-vi.mock('./MovieVote', () => ({
-	MovieVote: ({ vote }: { vote: number }) => (
-		<div data-testid="movie-vote">{vote}</div>
-	),
-}));
-
-// Mock DropdownMenu components to prevent multiple button issues
-vi.mock('@antoniobenincasa/ui', () => ({
-	DropdownMenu: ({ children }: { children: React.ReactNode }) => (
-		<div data-testid="dropdown-menu">{children}</div>
-	),
-	DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => (
-		<div data-testid="dropdown-trigger">{children}</div>
-	),
-	DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
-		<div data-testid="dropdown-content">{children}</div>
-	),
-	DropdownMenuItem: ({ children }: { children: React.ReactNode }) => (
-		<div data-testid="dropdown-item">{children}</div>
-	),
 }));
 
 describe('MovieLogItem Integration Tests', () => {
@@ -89,7 +67,7 @@ describe('MovieLogItem Integration Tests', () => {
 			// Simulate navigating back to list and clicking another movie
 			const log2 = createMockLog({
 				tmdbId: 278,
-				movie: { ...createMockLog().movie, title: 'Shawshank Redemption' },
+				movie: { ...createMockLog().movie!, title: 'Shawshank Redemption' },
 			});
 			rerender(<TestWrapper log={log2} />);
 
@@ -208,7 +186,7 @@ describe('MovieLogItem Integration Tests', () => {
 		it('should handle re-renders with different log data', () => {
 			const log1 = createMockLog({
 				tmdbId: 550,
-				movie: { ...createMockLog().movie, title: 'Fight Club' },
+				movie: { ...createMockLog().movie!, title: 'Fight Club' },
 			});
 			const { rerender } = render(<TestWrapper log={log1} />);
 
@@ -216,7 +194,7 @@ describe('MovieLogItem Integration Tests', () => {
 
 			const log2 = createMockLog({
 				tmdbId: 278,
-				movie: { ...createMockLog().movie, title: 'Shawshank Redemption' },
+				movie: { ...createMockLog().movie!, title: 'Shawshank Redemption' },
 			});
 			rerender(<TestWrapper log={log2} />);
 
@@ -349,7 +327,7 @@ describe('MovieLogItem Integration Tests', () => {
 
 			it('should handle missing vote average gracefully', () => {
 				const log = createMockLog({
-					movie: { ...createMockLog().movie, voteAverage: undefined },
+					movie: { ...createMockLog().movie!, voteAverage: undefined },
 				});
 				render(<TestWrapper log={log} />);
 
@@ -359,7 +337,7 @@ describe('MovieLogItem Integration Tests', () => {
 
 			it('should display component even with null movie title', () => {
 				const log = createMockLog({
-					movie: { ...createMockLog().movie, title: '' },
+					movie: { ...createMockLog().movie!, title: '' },
 				});
 				render(<TestWrapper log={log} />);
 
@@ -432,7 +410,7 @@ describe('MovieLogItem Integration Tests', () => {
 			it('should handle movie title with special characters', () => {
 				const log = createMockLog({
 					movie: {
-						...createMockLog().movie,
+						...createMockLog().movie!,
 						title: 'O\'Brien\'s "Movie" & Friends',
 					},
 				});
@@ -444,7 +422,7 @@ describe('MovieLogItem Integration Tests', () => {
 			it('should handle very long movie title', () => {
 				const longTitle = 'A'.repeat(500);
 				const log = createMockLog({
-					movie: { ...createMockLog().movie, title: longTitle },
+					movie: { ...createMockLog().movie!, title: longTitle },
 				});
 				render(<TestWrapper log={log} />);
 

--- a/src/features/movie/components/MovieLogItem.tsx
+++ b/src/features/movie/components/MovieLogItem.tsx
@@ -5,10 +5,15 @@ import {
 	DropdownMenuTrigger,
 } from '@antoniobenincasa/ui';
 import { MoreVertical } from 'lucide-react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
+import { DeleteMovieLogDialog } from '@/features/logs/components';
 import type { LogListItem } from '@/features/logs/models';
-import { useMovieLogDialogStore } from '@/features/logs/stores';
+import {
+	useMovieLogDialogStore,
+	useMovieLogStore,
+} from '@/features/logs/stores';
 import { MovieVote } from './MovieVote';
 
 interface MovieLogItemProps {
@@ -22,8 +27,11 @@ export const MovieLogItem = ({
 }: MovieLogItemProps) => {
 	const { t } = useTranslation();
 	const navigate = useNavigate();
+	const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
 
-	const { open } = useMovieLogDialogStore();
+	const { open, triggerUpdate } = useMovieLogDialogStore();
+	const { deleteLog } = useMovieLogStore();
+
 	const handleTitleClick = () => {
 		if (log.tmdbId) {
 			navigate(`/movies/${log.tmdbId}`);
@@ -34,6 +42,16 @@ export const MovieLogItem = ({
 		open({
 			movieToEdit: log,
 		});
+	};
+
+	const handleDelete = async () => {
+		try {
+			await deleteLog(log.id);
+			setIsDeleteDialogOpen(false);
+			triggerUpdate();
+		} catch {
+			// Error is handled by the store
+		}
 	};
 
 	return (
@@ -99,15 +117,22 @@ export const MovieLogItem = ({
 								{t('MovieLogItem.edit')}
 							</DropdownMenuItem>
 
-							{/* TODO: Implement delete functionality - see GitHub issue */}
-							{/* <DropdownMenuItem variant="destructive">
-							{' '}
-							{t('MovieLogItem.delete')}
-						</DropdownMenuItem> */}
+							<DropdownMenuItem
+								variant="destructive"
+								onClick={() => setIsDeleteDialogOpen(true)}
+							>
+								{t('MovieLogItem.delete')}
+							</DropdownMenuItem>
 						</DropdownMenuContent>
 					</DropdownMenu>
 				</div>
 			)}
+
+			<DeleteMovieLogDialog
+				isOpen={isDeleteDialogOpen}
+				onClose={() => setIsDeleteDialogOpen(false)}
+				onConfirm={handleDelete}
+			/>
 		</div>
 	);
 };

--- a/src/features/movie/components/MovieLogItem.unit.test.tsx
+++ b/src/features/movie/components/MovieLogItem.unit.test.tsx
@@ -4,12 +4,45 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { LogListItem } from '@/features/logs/models';
 import { MovieLogItem } from './MovieLogItem';
 
-// Mock useMovieLogDialogStore
+// Mock useMovieLogDialogStore and useMovieLogStore
 const mockOpen = vi.fn();
+const mockTriggerUpdate = vi.fn();
+const mockDeleteLog = vi.fn();
 vi.mock('@/features/logs/stores', () => ({
 	useMovieLogDialogStore: () => ({
 		open: mockOpen,
+		triggerUpdate: mockTriggerUpdate,
 	}),
+	useMovieLogStore: () => ({
+		deleteLog: mockDeleteLog,
+	}),
+}));
+
+// Mock DeleteMovieLogDialog
+vi.mock('@/features/logs/components', () => ({
+	DeleteMovieLogDialog: ({
+		isOpen,
+		onClose,
+		onConfirm,
+	}: {
+		isOpen: boolean;
+		onClose: () => void;
+		onConfirm: () => Promise<void>;
+	}) => (
+		<div data-testid="delete-dialog">
+			{isOpen && (
+				<div>
+					<span data-testid="dialog-open">open</span>
+					<button data-testid="dialog-confirm" onClick={onConfirm}>
+						Confirm
+					</button>
+					<button data-testid="dialog-cancel" onClick={onClose}>
+						Cancel
+					</button>
+				</div>
+			)}
+		</div>
+	),
 }));
 
 // Mock useNavigate from react-router-dom
@@ -86,6 +119,8 @@ describe('MovieLogItem', () => {
 	beforeEach(() => {
 		mockNavigate.mockClear();
 		mockOpen.mockClear();
+		mockTriggerUpdate.mockClear();
+		mockDeleteLog.mockClear();
 	});
 
 	describe('T3.1.1: Component Renders Without Crashing', () => {
@@ -277,12 +312,75 @@ describe('MovieLogItem', () => {
 			const log = createMockLog();
 			render(<MovieLogItem log={log} isDropdownMenuVisible={true} />);
 
-			const editButton = screen.getByTestId('dropdown-item');
-			await user.click(editButton);
+			const items = screen.getAllByTestId('dropdown-item');
+			await user.click(items[0]);
 
 			expect(mockOpen).toHaveBeenCalledWith({
 				movieToEdit: log,
 			});
+		});
+	});
+
+	describe('Delete Movie Log', () => {
+		it('should render delete menu item when dropdown is visible', () => {
+			const log = createMockLog();
+			render(<MovieLogItem log={log} isDropdownMenuVisible={true} />);
+
+			const items = screen.getAllByTestId('dropdown-item');
+			expect(items.length).toBe(2);
+			expect(items[1]).toHaveTextContent('MovieLogItem.delete');
+		});
+
+		it('should open delete confirmation dialog when delete is clicked', async () => {
+			const user = userEvent.setup();
+			const log = createMockLog();
+			render(<MovieLogItem log={log} isDropdownMenuVisible={true} />);
+
+			const items = screen.getAllByTestId('dropdown-item');
+			await user.click(items[1]);
+
+			expect(screen.getByTestId('dialog-open')).toBeInTheDocument();
+		});
+
+		it('should call deleteLog and triggerUpdate on confirm', async () => {
+			mockDeleteLog.mockResolvedValueOnce(undefined);
+			const user = userEvent.setup();
+			const log = createMockLog();
+			render(<MovieLogItem log={log} isDropdownMenuVisible={true} />);
+
+			const items = screen.getAllByTestId('dropdown-item');
+			await user.click(items[1]);
+			await user.click(screen.getByTestId('dialog-confirm'));
+
+			expect(mockDeleteLog).toHaveBeenCalledWith(log.id);
+			expect(mockTriggerUpdate).toHaveBeenCalled();
+		});
+
+		it('should not call triggerUpdate when delete fails', async () => {
+			mockDeleteLog.mockRejectedValueOnce(new Error('Delete failed'));
+			const user = userEvent.setup();
+			const log = createMockLog();
+			render(<MovieLogItem log={log} isDropdownMenuVisible={true} />);
+
+			const items = screen.getAllByTestId('dropdown-item');
+			await user.click(items[1]);
+			await user.click(screen.getByTestId('dialog-confirm'));
+
+			expect(mockDeleteLog).toHaveBeenCalledWith(log.id);
+			expect(mockTriggerUpdate).not.toHaveBeenCalled();
+		});
+
+		it('should close dialog when cancel is clicked', async () => {
+			const user = userEvent.setup();
+			const log = createMockLog();
+			render(<MovieLogItem log={log} isDropdownMenuVisible={true} />);
+
+			const items = screen.getAllByTestId('dropdown-item');
+			await user.click(items[1]);
+			expect(screen.getByTestId('dialog-open')).toBeInTheDocument();
+
+			await user.click(screen.getByTestId('dialog-cancel'));
+			expect(screen.queryByTestId('dialog-open')).not.toBeInTheDocument();
 		});
 	});
 

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -179,6 +179,12 @@
 		"submittingUpdate": "Updating Log...",
 		"error": "An error occurred while creating the log"
 	},
+	"DeleteMovieLogDialog": {
+		"title": "Delete Movie Log",
+		"description": "Are you sure you want to delete this movie log? This action cannot be undone.",
+		"cancel": "Cancel",
+		"confirm": "Delete"
+	},
 	"WatchedWhere": {
 		"cinema": "Cinema",
 		"streaming": "Streaming",

--- a/src/lib/locales/fr.json
+++ b/src/lib/locales/fr.json
@@ -175,6 +175,12 @@
 		"submittingUpdate": "Mise à jour du journal...",
 		"error": "Une erreur s'est produite lors de la création du journal"
 	},
+	"DeleteMovieLogDialog": {
+		"title": "Supprimer le journal",
+		"description": "Êtes-vous sûr de vouloir supprimer ce journal ? Cette action est irréversible.",
+		"cancel": "Annuler",
+		"confirm": "Supprimer"
+	},
 	"WatchedWhere": {
 		"cinema": "Cinéma",
 		"streaming": "Streaming",

--- a/src/lib/locales/it.json
+++ b/src/lib/locales/it.json
@@ -175,6 +175,12 @@
 		"submittingUpdate": "Aggiornamento Log...",
 		"error": "Si è verificato un errore durante la creazione del log"
 	},
+	"DeleteMovieLogDialog": {
+		"title": "Elimina Log Film",
+		"description": "Sei sicuro di voler eliminare questo log film? Questa azione non può essere annullata.",
+		"cancel": "Annulla",
+		"confirm": "Elimina"
+	},
 	"WatchedWhere": {
 		"cinema": "Cinema",
 		"streaming": "Streaming",


### PR DESCRIPTION
## Summary
- Add `deleteLog` API call to repository layer (`DELETE v1/logs/{logId}`)
- Add `deleteLog` action to `useMovieLogStore` with dedicated `isDeleteMovieLogLoading` loading flag
- Create `DeleteMovieLogDialog` confirmation dialog component
- Wire up delete button in `MovieLogItem` dropdown with confirmation flow
- Add locale strings for delete dialog in EN, IT, FR
- List refreshes automatically after successful deletion via existing `triggerUpdate()` mechanism
- Full error handling and proper loading states

## Closes
Closes #18