### PR TITLE
feat(theme): move theme selection to profile dropdown

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ function App() {
 	}, [fetchUserInfo]);
 
 	return (
-		<ThemeProvider defaultTheme="dark" storageKey="cinelog-theme">
+		<ThemeProvider defaultTheme="system" storageKey="cinelog-theme">
 			<NotificationProvider>
 				<BrowserRouter>
 					<AppRoutes />

--- a/src/App.unit.test.tsx
+++ b/src/App.unit.test.tsx
@@ -15,8 +15,22 @@ vi.mock('react-router-dom', () => ({
 }));
 
 vi.mock('./lib/components/ThemeProvider', () => ({
-	ThemeProvider: ({ children }: { children: React.ReactNode }) => (
-		<div data-testid="theme-provider">{children}</div>
+	ThemeProvider: ({
+		children,
+		defaultTheme,
+		storageKey,
+	}: {
+		children: React.ReactNode;
+		defaultTheme?: string;
+		storageKey?: string;
+	}) => (
+		<div
+			data-testid="theme-provider"
+			data-default-theme={defaultTheme}
+			data-storage-key={storageKey}
+		>
+			{children}
+		</div>
 	),
 }));
 
@@ -41,6 +55,19 @@ describe('App', () => {
 		render(<App />);
 
 		expect(screen.getByTestId('theme-provider')).toBeInTheDocument();
+	});
+
+	it('should configure ThemeProvider with system as the default theme', () => {
+		render(<App />);
+
+		expect(screen.getByTestId('theme-provider')).toHaveAttribute(
+			'data-default-theme',
+			'system'
+		);
+		expect(screen.getByTestId('theme-provider')).toHaveAttribute(
+			'data-storage-key',
+			'cinelog-theme'
+		);
 	});
 
 	it('should render BrowserRouter inside ThemeProvider', () => {

--- a/src/lib/components/Navbar.tsx
+++ b/src/lib/components/Navbar.tsx
@@ -1,10 +1,13 @@
 import {
 	Button,
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuTrigger,
 	NavigationMenu,
 	NavigationMenuLink,
 	NavigationMenuList,
 } from '@antoniobenincasa/ui';
-import { Menu, Moon, Sun, User } from 'lucide-react';
+import { Menu, Moon, Sun, SunMoon, User } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate } from 'react-router-dom';
@@ -19,6 +22,8 @@ import type { MobileNavbarItem } from '../models/mobile-navbar-item.model';
 import { Logo } from './Logo';
 import { MobileNavbar } from './MobileNavbar';
 import { ProfileDropdownMenu } from './ProfileDropdownMenu';
+import { ThemeDropdown } from './ThemeDropdown';
+import { ThemeIcon } from './ThemeIcon';
 
 export const Navbar = () => {
 	const { t } = useTranslation();
@@ -26,12 +31,8 @@ export const Navbar = () => {
 	const authenticatedStatus = useAuthStore(
 		(state) => state.authenticatedStatus
 	);
-	const { theme, setTheme } = useTheme();
+	const { theme } = useTheme();
 	const [isOpen, setIsOpen] = useState(false);
-
-	const toggleTheme = () => {
-		setTheme(theme === 'dark' ? 'light' : 'dark');
-	};
 
 	const navigationData: {
 		label: string;
@@ -86,23 +87,24 @@ export const Navbar = () => {
 
 				{/* Right side - Auth buttons or User menu */}
 				<div className="flex items-center gap-4">
-					<Button
-						variant="ghost"
-						size="icon"
-						onClick={toggleTheme}
-						aria-label="Toggle theme"
-					>
-						{theme === 'dark' ? (
-							<Sun className="w-5 h-5" />
-						) : (
-							<Moon className="w-5 h-5" />
-						)}
-					</Button>
-
 					{authenticatedStatus === true && <CreateMovieLogButton />}
 
 					{authenticatedStatus === false ? (
 						<>
+							<DropdownMenu>
+								<DropdownMenuTrigger asChild>
+									<Button
+										variant="ghost"
+										className="gap-2 px-3"
+										aria-label={t('Navbar.theme')}
+									>
+										<ThemeIcon theme={theme} />
+									</Button>
+								</DropdownMenuTrigger>
+								<DropdownMenuContent align="end">
+									<ThemeDropdown context="inline" />
+								</DropdownMenuContent>
+							</DropdownMenu>
 							<Button
 								variant="ghost"
 								size="icon"

--- a/src/lib/components/Navbar.unit.test.tsx
+++ b/src/lib/components/Navbar.unit.test.tsx
@@ -8,7 +8,7 @@ const mockSetTheme = vi.fn();
 
 const navbarState = {
 	authenticatedStatus: false as boolean | null,
-	theme: 'dark' as 'dark' | 'light',
+	theme: 'dark' as 'dark' | 'light' | 'system',
 	isMobile: false,
 };
 
@@ -62,6 +62,35 @@ vi.mock('@antoniobenincasa/ui', () => ({
 	NavigationMenuLink: ({ children }: { children?: ReactNode }) => (
 		<div>{children}</div>
 	),
+	DropdownMenu: ({ children }: { children?: ReactNode }) => (
+		<div>{children}</div>
+	),
+	DropdownMenuTrigger: ({ children }: { children?: ReactNode }) => (
+		<div>{children}</div>
+	),
+	DropdownMenuContent: ({ children }: { children?: ReactNode }) => (
+		<div>{children}</div>
+	),
+	DropdownMenuRadioGroup: ({
+		children,
+		value,
+	}: {
+		children?: ReactNode;
+		value?: string;
+	}) => <div data-value={value}>{children}</div>,
+	DropdownMenuRadioItem: ({
+		children,
+		onClick,
+		value,
+	}: {
+		children?: ReactNode;
+		onClick?: () => void;
+		value?: string;
+	}) => (
+		<button type="button" data-value={value} onClick={onClick}>
+			{children}
+		</button>
+	),
 }));
 
 vi.mock('lucide-react', () => ({
@@ -72,6 +101,7 @@ vi.mock('lucide-react', () => ({
 	),
 	Moon: () => <span>moon</span>,
 	Sun: () => <span>sun</span>,
+	SunMoon: () => <span>sun-moon</span>,
 	User: () => <span>user</span>,
 }));
 
@@ -153,28 +183,47 @@ describe('Navbar', () => {
 		expect(mockNavigate).toHaveBeenNthCalledWith(3, '/registration');
 	});
 
-	it('toggles theme based on current theme value', () => {
+	it('lets logged-out users select any theme from the navbar menu', () => {
 		render(
 			<MemoryRouter>
 				<Navbar />
 			</MemoryRouter>
 		);
 
-		fireEvent.click(screen.getByLabelText('Toggle theme'));
+		expect(screen.getByLabelText('Navbar.theme')).toBeInTheDocument();
+		expect(screen.getByLabelText('Navbar.theme')).toHaveTextContent('moon');
+		fireEvent.click(screen.getByText('ThemeDropdownRadioGroup.themes.light'));
+		fireEvent.click(screen.getByText('ThemeDropdownRadioGroup.themes.dark'));
+		fireEvent.click(screen.getByText('ThemeDropdownRadioGroup.themes.system'));
+
 		expect(mockSetTheme).toHaveBeenCalledWith('light');
+		expect(mockSetTheme).toHaveBeenCalledWith('dark');
+		expect(mockSetTheme).toHaveBeenCalledWith('system');
 	});
 
-	it('toggles from light to dark and renders moon icon path', () => {
-		navbarState.theme = 'light';
+	it('uses a sun-moon icon for the guest system theme trigger', () => {
+		navbarState.theme = 'system';
+
 		render(
 			<MemoryRouter>
 				<Navbar />
 			</MemoryRouter>
 		);
 
-		expect(screen.getByText('moon')).toBeInTheDocument();
-		fireEvent.click(screen.getByLabelText('Toggle theme'));
-		expect(mockSetTheme).toHaveBeenCalledWith('dark');
+		expect(screen.getByLabelText('Navbar.theme')).toHaveTextContent('sun-moon');
+	});
+
+	it('does not render the guest theme menu for authenticated users', () => {
+		navbarState.authenticatedStatus = true;
+
+		render(
+			<MemoryRouter>
+				<Navbar />
+			</MemoryRouter>
+		);
+
+		expect(screen.queryByLabelText('Navbar.theme')).not.toBeInTheDocument();
+		expect(screen.getByTestId('profile-dropdown')).toBeInTheDocument();
 	});
 
 	it('shows authenticated content and opens mobile navbar', () => {

--- a/src/lib/components/ProfileDropdownMenu.tsx
+++ b/src/lib/components/ProfileDropdownMenu.tsx
@@ -13,6 +13,7 @@ import { Languages, LogOut, User } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '@/features/auth/stores';
+import { ThemeDropdown } from './ThemeDropdown';
 
 export const ProfileDropdownMenu = () => {
 	const navigate = useNavigate();
@@ -70,6 +71,7 @@ export const ProfileDropdownMenu = () => {
 						</DropdownMenuItem>
 					</DropdownMenuSubContent>
 				</DropdownMenuSub>
+				<ThemeDropdown context="submenu" />
 				<DropdownMenuSeparator />
 				<DropdownMenuItem
 					variant="destructive"

--- a/src/lib/components/ProfileDropdownMenu.unit.test.tsx
+++ b/src/lib/components/ProfileDropdownMenu.unit.test.tsx
@@ -5,9 +5,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mockNavigate = vi.fn();
 const mockLogout = vi.fn();
 const mockChangeLanguage = vi.fn();
+const mockSetTheme = vi.fn();
 
 const authState = {
 	userInfo: { handle: 'neo' } as { handle: string } | null,
+	theme: 'system' as 'dark' | 'light' | 'system',
 };
 
 vi.mock('react-router-dom', async () => {
@@ -34,6 +36,10 @@ vi.mock('@/features/auth/stores', () => ({
 	) => selector({ logout: mockLogout, userInfo: authState.userInfo }),
 }));
 
+vi.mock('@/lib/hooks/useTheme', () => ({
+	useTheme: () => ({ theme: authState.theme, setTheme: mockSetTheme }),
+}));
+
 vi.mock('@antoniobenincasa/ui', () => ({
 	Button: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
 	DropdownMenu: ({ children }: { children?: ReactNode }) => (
@@ -54,6 +60,26 @@ vi.mock('@antoniobenincasa/ui', () => ({
 	DropdownMenuSubContent: ({ children }: { children?: ReactNode }) => (
 		<div>{children}</div>
 	),
+	DropdownMenuRadioGroup: ({
+		children,
+		value,
+	}: {
+		children?: ReactNode;
+		value?: string;
+	}) => <div data-value={value}>{children}</div>,
+	DropdownMenuRadioItem: ({
+		children,
+		onClick,
+		value,
+	}: {
+		children?: ReactNode;
+		onClick?: () => void;
+		value?: string;
+	}) => (
+		<button type="button" data-value={value} onClick={onClick}>
+			{children}
+		</button>
+	),
 	DropdownMenuSeparator: () => <hr />,
 	DropdownMenuItem: ({
 		children,
@@ -71,6 +97,7 @@ vi.mock('@antoniobenincasa/ui', () => ({
 vi.mock('lucide-react', () => ({
 	Languages: () => <span>languages-icon</span>,
 	LogOut: () => <span>logout-icon</span>,
+	SunMoon: () => <span>sun-moon-icon</span>,
 	User: () => <span>user-icon</span>,
 }));
 
@@ -80,6 +107,7 @@ describe('ProfileDropdownMenu', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		authState.userInfo = { handle: 'neo' };
+		authState.theme = 'system';
 		mockLogout.mockResolvedValue(undefined);
 	});
 
@@ -105,6 +133,30 @@ describe('ProfileDropdownMenu', () => {
 		expect(mockChangeLanguage).toHaveBeenCalledWith('en');
 		expect(mockChangeLanguage).toHaveBeenCalledWith('fr');
 		expect(mockChangeLanguage).toHaveBeenCalledWith('it');
+	});
+
+	it('changes theme from theme menu items', () => {
+		render(<ProfileDropdownMenu />);
+		fireEvent.click(screen.getByText('ThemeDropdownRadioGroup.themes.light'));
+		fireEvent.click(screen.getByText('ThemeDropdownRadioGroup.themes.dark'));
+		fireEvent.click(screen.getByText('ThemeDropdownRadioGroup.themes.system'));
+
+		expect(mockSetTheme).toHaveBeenCalledWith('light');
+		expect(mockSetTheme).toHaveBeenCalledWith('dark');
+		expect(mockSetTheme).toHaveBeenCalledWith('system');
+	});
+
+	it('marks the current theme in the theme menu', () => {
+		authState.theme = 'dark';
+
+		render(<ProfileDropdownMenu />);
+
+		expect(
+			screen.getByText('ThemeDropdownRadioGroup.themes.dark').parentElement
+		).toHaveAttribute('data-value', 'dark');
+		expect(
+			screen.getByText('ThemeDropdown.theme').parentElement
+		).toHaveTextContent('sun-moon-icon');
 	});
 
 	it('logs out and redirects home', async () => {

--- a/src/lib/components/ThemeDropdown.tsx
+++ b/src/lib/components/ThemeDropdown.tsx
@@ -1,0 +1,30 @@
+import {
+	DropdownMenuSub,
+	DropdownMenuSubContent,
+	DropdownMenuSubTrigger,
+} from '@antoniobenincasa/ui';
+import { SunMoon } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { ThemeDropdownRadioGroup } from './ThemeDropdownRadioGroup';
+
+type ThemeDropdownProps = {
+	context: 'inline' | 'submenu';
+};
+
+export const ThemeDropdown = ({ context }: ThemeDropdownProps) => {
+	const { t } = useTranslation();
+
+	if (context === 'inline') return <ThemeDropdownRadioGroup />;
+
+	return (
+		<DropdownMenuSub>
+			<DropdownMenuSubTrigger className="flex items-center gap-2">
+				<SunMoon className="w-4 h-4" />
+				{t('ThemeDropdown.theme')}
+			</DropdownMenuSubTrigger>
+			<DropdownMenuSubContent>
+				<ThemeDropdownRadioGroup />
+			</DropdownMenuSubContent>
+		</DropdownMenuSub>
+	);
+};

--- a/src/lib/components/ThemeDropdown.unit.test.tsx
+++ b/src/lib/components/ThemeDropdown.unit.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({
+		t: (key: string) => key,
+	}),
+}));
+
+vi.mock('@antoniobenincasa/ui', () => ({
+	DropdownMenuSub: ({ children }: { children?: ReactNode }) => (
+		<div>{children}</div>
+	),
+	DropdownMenuSubContent: ({ children }: { children?: ReactNode }) => (
+		<div>{children}</div>
+	),
+	DropdownMenuSubTrigger: ({ children }: { children?: ReactNode }) => (
+		<div>{children}</div>
+	),
+}));
+
+vi.mock('lucide-react', () => ({
+	SunMoon: () => <span>sun-moon-icon</span>,
+}));
+
+vi.mock('./ThemeDropdownRadioGroup', () => ({
+	ThemeDropdownRadioGroup: () => <div data-testid="theme-radio-group" />,
+}));
+
+import { ThemeDropdown } from './ThemeDropdown';
+
+describe('ThemeDropdown', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('renders inline radio group content', () => {
+		render(<ThemeDropdown context="inline" />);
+
+		expect(screen.getByTestId('theme-radio-group')).toBeInTheDocument();
+	});
+
+	it('renders submenu trigger and radio group content', () => {
+		render(<ThemeDropdown context="submenu" />);
+
+		expect(
+			screen.getByText('ThemeDropdown.theme').parentElement
+		).toHaveTextContent('sun-moon-icon');
+		expect(screen.getByTestId('theme-radio-group')).toBeInTheDocument();
+	});
+});

--- a/src/lib/components/ThemeDropdownRadioGroup.tsx
+++ b/src/lib/components/ThemeDropdownRadioGroup.tsx
@@ -1,0 +1,33 @@
+import {
+	DropdownMenuRadioGroup,
+	DropdownMenuRadioItem,
+} from '@antoniobenincasa/ui';
+import { useTranslation } from 'react-i18next';
+import { useTheme } from '@/lib/hooks/useTheme';
+import type { Theme } from '@/lib/models';
+
+export const ThemeDropdownRadioGroup = () => {
+	const { t } = useTranslation();
+	const { theme, setTheme } = useTheme();
+
+	const changeTheme = (theme: Theme) => {
+		setTheme(theme);
+	};
+
+	return (
+		<DropdownMenuRadioGroup value={theme}>
+			<DropdownMenuRadioItem value="light" onClick={() => changeTheme('light')}>
+				{t('ThemeDropdownRadioGroup.themes.light')}
+			</DropdownMenuRadioItem>
+			<DropdownMenuRadioItem value="dark" onClick={() => changeTheme('dark')}>
+				{t('ThemeDropdownRadioGroup.themes.dark')}
+			</DropdownMenuRadioItem>
+			<DropdownMenuRadioItem
+				value="system"
+				onClick={() => changeTheme('system')}
+			>
+				{t('ThemeDropdownRadioGroup.themes.system')}
+			</DropdownMenuRadioItem>
+		</DropdownMenuRadioGroup>
+	);
+};

--- a/src/lib/components/ThemeDropdownRadioGroup.unit.test.tsx
+++ b/src/lib/components/ThemeDropdownRadioGroup.unit.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockSetTheme = vi.fn();
+
+const themeState = {
+	theme: 'system' as 'dark' | 'light' | 'system',
+};
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({
+		t: (key: string) => key,
+	}),
+}));
+
+vi.mock('@/lib/hooks/useTheme', () => ({
+	useTheme: () => ({ theme: themeState.theme, setTheme: mockSetTheme }),
+}));
+
+vi.mock('@antoniobenincasa/ui', () => ({
+	DropdownMenuRadioGroup: ({
+		children,
+		value,
+	}: {
+		children?: ReactNode;
+		value?: string;
+	}) => <div data-value={value}>{children}</div>,
+	DropdownMenuRadioItem: ({
+		children,
+		onClick,
+		value,
+	}: {
+		children?: ReactNode;
+		onClick?: () => void;
+		value?: string;
+	}) => (
+		<button type="button" data-value={value} onClick={onClick}>
+			{children}
+		</button>
+	),
+}));
+
+import { ThemeDropdownRadioGroup } from './ThemeDropdownRadioGroup';
+
+describe('ThemeDropdownRadioGroup', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		themeState.theme = 'system';
+	});
+
+	it('renders theme choices and changes theme', () => {
+		render(<ThemeDropdownRadioGroup />);
+
+		fireEvent.click(screen.getByText('ThemeDropdownRadioGroup.themes.light'));
+		fireEvent.click(screen.getByText('ThemeDropdownRadioGroup.themes.dark'));
+		fireEvent.click(screen.getByText('ThemeDropdownRadioGroup.themes.system'));
+
+		expect(mockSetTheme).toHaveBeenCalledWith('light');
+		expect(mockSetTheme).toHaveBeenCalledWith('dark');
+		expect(mockSetTheme).toHaveBeenCalledWith('system');
+	});
+
+	it('marks the current theme value', () => {
+		themeState.theme = 'dark';
+
+		render(<ThemeDropdownRadioGroup />);
+
+		expect(
+			screen.getByText('ThemeDropdownRadioGroup.themes.dark').parentElement
+		).toHaveAttribute('data-value', 'dark');
+	});
+});

--- a/src/lib/components/ThemeIcon.tsx
+++ b/src/lib/components/ThemeIcon.tsx
@@ -1,0 +1,8 @@
+import { Moon, Sun, SunMoon } from 'lucide-react';
+import type { Theme } from '../models';
+
+export const ThemeIcon = ({ theme }: { theme: Theme }) => {
+	if (theme === 'dark') return <Moon className="w-4 h-4" />;
+	if (theme === 'light') return <Sun className="w-4 h-4" />;
+	return <SunMoon className="w-4 h-4" />;
+};

--- a/src/lib/components/ThemeIcon.unit.test.tsx
+++ b/src/lib/components/ThemeIcon.unit.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('lucide-react', () => ({
+	Moon: ({ className }: { className?: string }) => (
+		<span data-testid="moon-icon" className={className} />
+	),
+	Sun: ({ className }: { className?: string }) => (
+		<span data-testid="sun-icon" className={className} />
+	),
+	SunMoon: ({ className }: { className?: string }) => (
+		<span data-testid="sun-moon-icon" className={className} />
+	),
+}));
+
+import { ThemeIcon } from './ThemeIcon';
+
+describe('ThemeIcon', () => {
+	it('renders the moon icon for the dark theme', () => {
+		render(<ThemeIcon theme="dark" />);
+
+		expect(screen.getByTestId('moon-icon')).toBeInTheDocument();
+		expect(screen.queryByTestId('sun-icon')).not.toBeInTheDocument();
+		expect(screen.queryByTestId('sun-moon-icon')).not.toBeInTheDocument();
+	});
+
+	it('renders the sun icon for the light theme', () => {
+		render(<ThemeIcon theme="light" />);
+
+		expect(screen.getByTestId('sun-icon')).toBeInTheDocument();
+		expect(screen.queryByTestId('moon-icon')).not.toBeInTheDocument();
+		expect(screen.queryByTestId('sun-moon-icon')).not.toBeInTheDocument();
+	});
+
+	it('renders the sun-moon icon for the system theme', () => {
+		render(<ThemeIcon theme="system" />);
+
+		expect(screen.getByTestId('sun-moon-icon')).toBeInTheDocument();
+		expect(screen.queryByTestId('moon-icon')).not.toBeInTheDocument();
+		expect(screen.queryByTestId('sun-icon')).not.toBeInTheDocument();
+	});
+
+	it('falls back to the sun-moon icon for an unknown theme', () => {
+		render(<ThemeIcon theme="unknown" />);
+
+		expect(screen.getByTestId('sun-moon-icon')).toBeInTheDocument();
+	});
+
+	it('applies the icon sizing classes', () => {
+		render(<ThemeIcon theme="dark" />);
+
+		expect(screen.getByTestId('moon-icon')).toHaveClass('w-4', 'h-4');
+	});
+});

--- a/src/lib/components/ThemeProvider.tsx
+++ b/src/lib/components/ThemeProvider.tsx
@@ -21,19 +21,28 @@ export function ThemeProvider({
 	useEffect(() => {
 		const root = window.document.documentElement;
 
-		root.classList.remove('light', 'dark');
+		const applyTheme = (theme: 'dark' | 'light') => {
+			root.classList.remove('light', 'dark');
+			root.classList.add(theme);
+		};
 
 		if (theme === 'system') {
-			const systemTheme = window.matchMedia('(prefers-color-scheme: dark)')
-				.matches
-				? 'dark'
-				: 'light';
+			const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+			const applySystemTheme = (
+				event?: MediaQueryListEvent | { matches: boolean }
+			) => {
+				applyTheme((event?.matches ?? mediaQuery.matches) ? 'dark' : 'light');
+			};
 
-			root.classList.add(systemTheme);
-			return;
+			applySystemTheme();
+			mediaQuery.addEventListener('change', applySystemTheme);
+
+			return () => {
+				mediaQuery.removeEventListener('change', applySystemTheme);
+			};
 		}
 
-		root.classList.add(theme);
+		applyTheme(theme);
 	}, [theme]);
 
 	const value = {

--- a/src/lib/components/ThemeProvider.unit.test.tsx
+++ b/src/lib/components/ThemeProvider.unit.test.tsx
@@ -7,6 +7,7 @@ describe('ThemeProvider', () => {
 	beforeEach(() => {
 		localStorage.clear();
 		document.documentElement.className = '';
+		vi.unstubAllGlobals();
 	});
 
 	it('uses stored theme and applies class', () => {
@@ -88,6 +89,43 @@ describe('ThemeProvider', () => {
 
 		expect(screen.getByTestId('child-light')).toBeInTheDocument();
 		expect(document.documentElement).toHaveClass('light');
-		vi.unstubAllGlobals();
+	});
+
+	it('updates the applied theme when system preference changes', async () => {
+		let changeListener:
+			| ((event: MediaQueryListEvent | { matches: boolean }) => void)
+			| undefined;
+
+		vi.stubGlobal(
+			'matchMedia',
+			vi.fn().mockReturnValue({
+				matches: false,
+				media: '(prefers-color-scheme: dark)',
+				addEventListener: vi.fn(
+					(
+						eventName: string,
+						listener: (
+							event: MediaQueryListEvent | { matches: boolean }
+						) => void
+					) => {
+						if (eventName === 'change') changeListener = listener;
+					}
+				),
+				removeEventListener: vi.fn(),
+			})
+		);
+
+		render(
+			<ThemeProvider defaultTheme="system">
+				<span data-testid="child-system-change">child</span>
+			</ThemeProvider>
+		);
+
+		expect(document.documentElement).toHaveClass('light');
+		changeListener?.({ matches: true });
+
+		await waitFor(() => {
+			expect(document.documentElement).toHaveClass('dark');
+		});
 	});
 });

--- a/src/lib/components/index.ts
+++ b/src/lib/components/index.ts
@@ -1,4 +1,6 @@
 export { DefaultLayout } from './DefaultLayout';
 export { Navbar } from './Navbar';
 export { OwnerRoute } from './OwnerRoute';
+export { ThemeDropdown } from './ThemeDropdown';
+export { ThemeDropdownRadioGroup } from './ThemeDropdownRadioGroup';
 export { ThemeProvider } from './ThemeProvider';

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -14,6 +14,16 @@
 			"it": "Italian"
 		}
 	},
+	"ThemeDropdown": {
+		"theme": "Theme"
+	},
+	"ThemeDropdownRadioGroup": {
+		"themes": {
+			"light": "Light",
+			"dark": "Dark",
+			"system": "Match system"
+		}
+	},
 	"MoviesWatched": {
 		"filterByYear": "Filter by Year:",
 		"selectYear": "Select year",
@@ -204,6 +214,7 @@
 	"Navbar": {
 		"home": "Home",
 		"search": "Search",
+		"theme": "Theme",
 		"login": "Login",
 		"register": "Register"
 	},

--- a/src/lib/locales/fr.json
+++ b/src/lib/locales/fr.json
@@ -14,6 +14,16 @@
 			"it": "Italien"
 		}
 	},
+	"ThemeDropdown": {
+		"theme": "Thème"
+	},
+	"ThemeDropdownRadioGroup": {
+		"themes": {
+			"light": "Clair",
+			"dark": "Sombre",
+			"system": "Utiliser le thème système"
+		}
+	},
 	"MoviesWatched": {
 		"filterByYear": "Filtrer par Année:",
 		"selectYear": "Sélectionner l'année",
@@ -200,6 +210,7 @@
 	"Navbar": {
 		"home": "Accueil",
 		"search": "Rechercher",
+		"theme": "Thème",
 		"login": "Connexion",
 		"register": "S'inscrire"
 	},

--- a/src/lib/locales/it.json
+++ b/src/lib/locales/it.json
@@ -14,6 +14,16 @@
 			"it": "Italiano"
 		}
 	},
+	"ThemeDropdown": {
+		"theme": "Tema"
+	},
+	"ThemeDropdownRadioGroup": {
+		"themes": {
+			"light": "Chiaro",
+			"dark": "Scuro",
+			"system": "Usa tema di sistema"
+		}
+	},
 	"MoviesWatched": {
 		"filterByYear": "Filtra per Anno:",
 		"selectYear": "Seleziona anno",
@@ -200,6 +210,7 @@
 	"Navbar": {
 		"home": "Home",
 		"search": "Cerca",
+		"theme": "Tema",
 		"login": "Accedi",
 		"register": "Registrati"
 	},


### PR DESCRIPTION
## Summary

Moves theme selection into the profile dropdown menu (issue #57) and bundles related movie-log improvements made on this branch.

### Theme selection (#57)
- Add `ThemeDropdown` and `ThemeDropdownRadioGroup` components, supporting both `inline` and `submenu` contexts.
- Wire theme selection into `ProfileDropdownMenu` and update `Navbar` accordingly.
- Update `ThemeProvider` and add localized strings (en/fr/it).

### Movie log
- Add delete movie log functionality with a confirmation dialog (`DeleteMovieLogDialog`).
- Improve `MovieLogItem` mobile layout.
- Change the movie-rating GET endpoint signature.

## Test plan
- [ ] Unit/integration tests pass (`bun test`)
- [ ] Theme can be switched from the profile dropdown
- [ ] Deleting a movie log shows the confirmation dialog and removes the entry
