### PR TITLE
fix(icons): remove unused theme icons from Navbar

### DIFF
--- a/src/lib/components/Navbar.tsx
+++ b/src/lib/components/Navbar.tsx
@@ -7,7 +7,7 @@ import {
 	NavigationMenuLink,
 	NavigationMenuList,
 } from '@antoniobenincasa/ui';
-import { Menu, Moon, Sun, SunMoon, User } from 'lucide-react';
+import { Menu, User } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate } from 'react-router-dom';


### PR DESCRIPTION
## Summary

Removes the three unused `lucide-react` icon imports (`Moon`, `Sun`, `SunMoon`) from `src/lib/components/Navbar.tsx`. These are dead imports — theme icons are now rendered by the `ThemeIcon` component.

```diff
-import { Menu, Moon, Sun, SunMoon, User } from 'lucide-react';
+import { Menu, User } from 'lucide-react';
```

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)