### PR TITLE
refactor(profile): rename friends_only visibility to followers_only

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ bun run test:unit
 bun run test:integration
 ```
 
+## Release Runbooks
+
+- [Followers-only profile visibility](docs/profile-visibility-release.md) — coordinated frontend/backend deployment, smoke checks, and rollback
+
 ## Related Repository
 
 - Backend: [cinelog_server](https://github.com/benincasantonio/cinelog_server)

--- a/docs/profile-visibility-release.md
+++ b/docs/profile-visibility-release.md
@@ -1,0 +1,70 @@
+# Followers-Only Profile Visibility Release
+
+The `followers_only` profile visibility value is a breaking replacement for
+`friends_only`. The frontend and backend intentionally do not accept the other
+version's wire value, so
+[cinelog_web#70](https://github.com/benincasantonio/cinelog_web/issues/70) and
+[cinelog_server#195](https://github.com/benincasantonio/cinelog_server/issues/195)
+must ship as one coordinated release.
+
+The backend's
+[technical profile-visibility guide](https://github.com/benincasantonio/cinelog_server/blob/main/docs/technical/profile-visibility.md)
+is the authoritative migration and database verification runbook.
+
+## Deployment
+
+Prefer roll-forward after backend migration `005_rename_profile_visibility`
+reaches production.
+
+1. Rehearse the backend migration and prepare matching backend and frontend
+   release artifacts.
+2. If any client/server mismatch is unacceptable, enable a short maintenance or
+   read-only window for registration and profile settings.
+3. Deploy the new backend first and wait for its automatic Alembic migration to
+   finish.
+4. Confirm the database is at revision `005_rename_profile_visibility`. Verify
+   that migrated rows use `followers_only` and that the profile-visibility check
+   constraint allows exactly `public`, `followers_only`, and `private`.
+5. Smoke-test the backend contract: registration and profile updates accept and
+   return `followers_only`, while `friends_only` receives a validation error.
+6. Deploy this frontend immediately after the backend smoke check.
+7. Complete the frontend smoke checks below, then disable maintenance/read-only
+   mode if it was enabled.
+
+## Frontend Smoke Checks
+
+- Open registration and confirm Public, Followers only, and Private are visible,
+  with Private selected by default.
+- Register a smoke-test account with Followers only and confirm the account is
+  created with `profileVisibility: "followers_only"`.
+- In profile settings, change visibility to Followers only, save, reload, and
+  confirm the selection persists.
+- Open the smoke-test account's own profile and confirm it renders normally.
+- Open an existing profile migrated from the legacy follower-only value and
+  confirm its full content remains restricted to another user until follower
+  authorization is delivered.
+- Recheck an existing Public and Private profile to confirm their behavior is
+  unchanged.
+
+## Rollback
+
+Use rollback only when roll-forward is not viable.
+
+1. Enable maintenance mode for registration and profile settings.
+2. While the new backend image that contains revision
+   `005_rename_profile_visibility` is still deployed, downgrade the database:
+
+   ```bash
+   docker compose -f docker-compose.prod.yml run --rm --no-deps db-migrate alembic downgrade 004_create_logs_table
+   docker compose -f docker-compose.prod.yml run --rm --no-deps db-migrate alembic current
+   ```
+
+3. Confirm revision `004_create_logs_table`, the reverse data conversion, and
+   the restored database constraint.
+4. Deploy the old backend and old frontend together.
+5. Smoke-test registration and profile settings against the restored contract,
+   then disable maintenance mode.
+
+Do not deploy the old backend image before the downgrade. The old image does not
+contain migration revision `005` and may be unable to resolve the database's
+current revision.

--- a/src/features/auth/components/RegistrationForm.unit.test.tsx
+++ b/src/features/auth/components/RegistrationForm.unit.test.tsx
@@ -54,6 +54,13 @@ vi.mock('@/features/profile/components/ProfileVisibilitySelect', () => ({
 			>
 				public
 			</button>
+			<button
+				type="button"
+				data-testid="select-followers-only"
+				onClick={() => onChange('followers_only')}
+			>
+				followers_only
+			</button>
 		</div>
 	),
 }));
@@ -375,11 +382,11 @@ describe('RegistrationForm', () => {
 			await act(async () => resolveRegistration!());
 		});
 
-		it('submits the selected profile visibility', async () => {
+		it('submits followers-only visibility unchanged', async () => {
 			mockRegister.mockResolvedValueOnce(undefined);
 			render(<RegistrationForm />);
 			fillDetails();
-			fireEvent.click(screen.getByTestId('select-public'));
+			fireEvent.click(screen.getByTestId('select-followers-only'));
 			fireEvent.change(
 				screen.getByPlaceholderText('RegistrationForm.codePlaceholder'),
 				{ target: { value: 'ABC123' } }
@@ -392,7 +399,7 @@ describe('RegistrationForm', () => {
 
 			await waitFor(() => {
 				expect(mockRegister).toHaveBeenCalledWith(
-					expect.objectContaining({ profileVisibility: 'public' })
+					expect.objectContaining({ profileVisibility: 'followers_only' })
 				);
 			});
 		});

--- a/src/features/auth/schemas/registration.schema.unit.test.ts
+++ b/src/features/auth/schemas/registration.schema.unit.test.ts
@@ -1,0 +1,36 @@
+import type { TFunction } from 'i18next';
+import { describe, expect, it } from 'vitest';
+import { createRegistrationSchema } from './registration.schema';
+
+const t = ((key: string) => key) as TFunction;
+const validRegistration = {
+	firstName: 'John',
+	lastName: 'Doe',
+	email: 'john@example.com',
+	password: 'password123',
+	handle: 'johndoe',
+	dateOfBirth: new Date('2000-01-01T00:00:00.000Z'),
+	bio: '',
+	verificationCode: 'ABC123',
+};
+
+describe('createRegistrationSchema', () => {
+	it('accepts followers-only visibility', () => {
+		const result = createRegistrationSchema(t).safeParse({
+			...validRegistration,
+			profileVisibility: 'followers_only',
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects the legacy visibility value', () => {
+		const legacyVisibility = ['friends', 'only'].join('_');
+		const result = createRegistrationSchema(t).safeParse({
+			...validRegistration,
+			profileVisibility: legacyVisibility,
+		});
+
+		expect(result.success).toBe(false);
+	});
+});

--- a/src/features/profile/components/ProfileVisibilitySelect.tsx
+++ b/src/features/profile/components/ProfileVisibilitySelect.tsx
@@ -5,34 +5,42 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from '@antoniobenincasa/ui';
+import { useId } from 'react';
 import { useTranslation } from 'react-i18next';
-import type { ProfileVisibility } from '@/lib/models';
+import {
+	PROFILE_VISIBILITY_VALUES,
+	type ProfileVisibility,
+} from '@/lib/models';
 
 type ProfileVisibilitySelectProps = {
 	value: ProfileVisibility;
 	onChange: (value: ProfileVisibility) => void;
 };
 
-const VISIBLE_OPTIONS: ProfileVisibility[] = ['public', 'private'];
-
 export const ProfileVisibilitySelect = ({
 	value,
 	onChange,
 }: ProfileVisibilitySelectProps) => {
 	const { t } = useTranslation();
+	const descriptionId = useId();
 
 	return (
-		<Select value={value} onValueChange={onChange}>
-			<SelectTrigger className="w-full">
-				<SelectValue />
-			</SelectTrigger>
-			<SelectContent>
-				{VISIBLE_OPTIONS.map((option) => (
-					<SelectItem key={option} value={option}>
-						{t(`ProfileVisibilitySelect.${option}`)}
-					</SelectItem>
-				))}
-			</SelectContent>
-		</Select>
+		<div className="grid gap-2">
+			<Select value={value} onValueChange={onChange}>
+				<SelectTrigger className="w-full" aria-describedby={descriptionId}>
+					<SelectValue />
+				</SelectTrigger>
+				<SelectContent>
+					{PROFILE_VISIBILITY_VALUES.map((option) => (
+						<SelectItem key={option} value={option}>
+							{t(`ProfileVisibilitySelect.${option}`)}
+						</SelectItem>
+					))}
+				</SelectContent>
+			</Select>
+			<p id={descriptionId} className="text-muted-foreground text-sm">
+				{t(`ProfileVisibilitySelect.descriptions.${value}`)}
+			</p>
+		</div>
 	);
 };

--- a/src/features/profile/components/ProfileVisibilitySelect.unit.test.tsx
+++ b/src/features/profile/components/ProfileVisibilitySelect.unit.test.tsx
@@ -35,16 +35,21 @@ vi.mock('@antoniobenincasa/ui', () => ({
 			</button>
 			<button
 				type="button"
-				data-testid="select-friends-only"
-				onClick={() => onValueChange('friends_only')}
+				data-testid="select-followers-only"
+				onClick={() => onValueChange('followers_only')}
 			>
-				friends_only
+				followers_only
 			</button>
 			{children}
 		</div>
 	),
-	SelectTrigger: ({ children }: { children: React.ReactNode }) => (
-		<div>{children}</div>
+	SelectTrigger: ({
+		children,
+		...props
+	}: React.HTMLAttributes<HTMLDivElement>) => (
+		<div data-testid="select-trigger" {...props}>
+			{children}
+		</div>
 	),
 	SelectValue: () => <span />,
 	SelectContent: ({ children }: { children: React.ReactNode }) => (
@@ -77,19 +82,27 @@ describe('ProfileVisibilitySelect', () => {
 		);
 	});
 
-	it('should render public and private options', () => {
+	it('should render every supported visibility option', () => {
 		render(<ProfileVisibilitySelect value="private" onChange={mockOnChange} />);
 
 		expect(screen.getByTestId('select-item-public')).toBeInTheDocument();
+		expect(
+			screen.getByTestId('select-item-followers_only')
+		).toBeInTheDocument();
 		expect(screen.getByTestId('select-item-private')).toBeInTheDocument();
+		expect(screen.getAllByTestId(/^select-item-/)).toHaveLength(3);
 	});
 
-	it('should not render friends_only option', () => {
+	it('should describe the selected visibility below the selector', () => {
 		render(<ProfileVisibilitySelect value="private" onChange={mockOnChange} />);
 
-		expect(
-			screen.queryByTestId('select-item-friends_only')
-		).not.toBeInTheDocument();
+		const description = screen.getByText(
+			'ProfileVisibilitySelect.descriptions.private'
+		);
+		expect(screen.getByTestId('select-trigger')).toHaveAttribute(
+			'aria-describedby',
+			description.id
+		);
 	});
 
 	it('should call onChange with public when public is selected', async () => {
@@ -108,5 +121,14 @@ describe('ProfileVisibilitySelect', () => {
 		await user.click(screen.getByTestId('select-private'));
 
 		expect(mockOnChange).toHaveBeenCalledWith('private');
+	});
+
+	it('should call onChange with followers_only when followers only is selected', async () => {
+		const user = userEvent.setup();
+		render(<ProfileVisibilitySelect value="private" onChange={mockOnChange} />);
+
+		await user.click(screen.getByTestId('select-followers-only'));
+
+		expect(mockOnChange).toHaveBeenCalledWith('followers_only');
 	});
 });

--- a/src/features/profile/components/UpdateProfileForm.unit.test.tsx
+++ b/src/features/profile/components/UpdateProfileForm.unit.test.tsx
@@ -67,6 +67,11 @@ vi.mock('./ProfileVisibilitySelect', () => ({
 				data-testid="visibility-private"
 				onClick={() => onChange('private')}
 			/>
+			<button
+				type="button"
+				data-testid="visibility-followers-only"
+				onClick={() => onChange('followers_only')}
+			/>
 		</div>
 	),
 }));
@@ -370,22 +375,22 @@ describe('UpdateProfileForm', () => {
 			);
 		});
 
-		it('should send profileVisibility in payload when changed', async () => {
+		it('should send followers-only visibility unchanged when selected', async () => {
 			const updatedUser = {
 				...mockUserInfo,
-				profileVisibility: 'public' as const,
+				profileVisibility: 'followers_only' as const,
 			};
 			mockUpdateProfile.mockResolvedValueOnce(updatedUser);
 			render(<UpdateProfileForm />);
 
-			fireEvent.click(screen.getByTestId('visibility-public'));
+			fireEvent.click(screen.getByTestId('visibility-followers-only'));
 			fireEvent.click(
 				screen.getByRole('button', { name: 'UpdateProfileForm.submit' })
 			);
 
 			await waitFor(() => {
 				expect(mockUpdateProfile).toHaveBeenCalledWith({
-					profileVisibility: 'public',
+					profileVisibility: 'followers_only',
 				});
 			});
 		});
@@ -412,15 +417,15 @@ describe('UpdateProfileForm', () => {
 			).toBeEnabled();
 		});
 
-		it('should reset form with updated visibility after save', async () => {
+		it('should retain followers-only visibility after save', async () => {
 			const updatedUser = {
 				...mockUserInfo,
-				profileVisibility: 'public' as const,
+				profileVisibility: 'followers_only' as const,
 			};
 			mockUpdateProfile.mockResolvedValueOnce(updatedUser);
 			render(<UpdateProfileForm />);
 
-			fireEvent.click(screen.getByTestId('visibility-public'));
+			fireEvent.click(screen.getByTestId('visibility-followers-only'));
 			fireEvent.click(
 				screen.getByRole('button', { name: 'UpdateProfileForm.submit' })
 			);
@@ -428,7 +433,7 @@ describe('UpdateProfileForm', () => {
 			await waitFor(() => {
 				expect(screen.getByTestId('profile-visibility-select')).toHaveAttribute(
 					'data-value',
-					'public'
+					'followers_only'
 				);
 			});
 

--- a/src/features/profile/pages/ProfilePage.unit.test.tsx
+++ b/src/features/profile/pages/ProfilePage.unit.test.tsx
@@ -156,6 +156,36 @@ describe('ProfilePage', () => {
 		);
 	});
 
+	it('keeps another user followers-only profile restricted', async () => {
+		const followersOnlyProfile = {
+			firstName: 'Oracle',
+			lastName: 'Guide',
+			handle: 'oracle',
+			dateOfBirth: '',
+			profileVisibility: 'followers_only',
+		};
+
+		mockUseAuthStore.mockReturnValue({
+			userInfo: ownUserInfo,
+			isUserInfoLoading: false,
+		});
+		mockGetProfile.mockResolvedValueOnce(followersOnlyProfile);
+
+		renderWithRouter('oracle');
+
+		await waitFor(() =>
+			expect(screen.getByTestId('profile')).toBeInTheDocument()
+		);
+
+		expect(screen.getByTestId('profile')).toHaveTextContent(
+			JSON.stringify({
+				userInfo: followersOnlyProfile,
+				isOwnProfile: false,
+				isPrivate: true,
+			})
+		);
+	});
+
 	it('renders nothing when profile fetch fails with non-USER_NOT_FOUND error', async () => {
 		mockUseAuthStore.mockReturnValue({
 			userInfo: ownUserInfo,

--- a/src/features/profile/schemas/update-profile.schema.unit.test.ts
+++ b/src/features/profile/schemas/update-profile.schema.unit.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { updateProfileSchema } from './update-profile.schema';
+
+const schema = updateProfileSchema({
+	firstNameRequired: 'First name is required',
+	lastNameRequired: 'Last name is required',
+	dateOfBirthRequired: 'Date of birth is required',
+	dateOfBirthInvalidFormat: 'Date of birth has an invalid format',
+	dateOfBirthInvalidDate: 'Date of birth is invalid',
+	dateOfBirthPast: 'Date of birth must be in the past',
+});
+
+const validProfile = {
+	firstName: 'Jane',
+	lastName: 'Doe',
+	bio: '',
+	dateOfBirth: '1990-01-15',
+};
+
+describe('updateProfileSchema', () => {
+	it('accepts followers-only visibility', () => {
+		const result = schema.safeParse({
+			...validProfile,
+			profileVisibility: 'followers_only',
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects the legacy visibility value', () => {
+		const legacyVisibility = ['friends', 'only'].join('_');
+		const result = schema.safeParse({
+			...validProfile,
+			profileVisibility: legacyVisibility,
+		});
+
+		expect(result.success).toBe(false);
+	});
+});

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -343,6 +343,12 @@
 	"ProfileVisibilitySelect": {
 		"label": "Profile Visibility",
 		"public": "Public",
-		"private": "Private"
+		"followers_only": "Followers only",
+		"private": "Private",
+		"descriptions": {
+			"public": "Anyone can view your full profile and movie logs.",
+			"followers_only": "Only followers you accept can view your full profile and movie logs.",
+			"private": "Only you can view your full profile and movie logs."
+		}
 	}
 }

--- a/src/lib/locales/fr.json
+++ b/src/lib/locales/fr.json
@@ -339,6 +339,12 @@
 	"ProfileVisibilitySelect": {
 		"label": "Visibilité du profil",
 		"public": "Public",
-		"private": "Privé"
+		"followers_only": "Abonnés uniquement",
+		"private": "Privé",
+		"descriptions": {
+			"public": "Tout le monde peut voir votre profil complet et les films que vous avez enregistrés.",
+			"followers_only": "Seuls les abonnés que vous acceptez peuvent voir votre profil complet et les films que vous avez enregistrés.",
+			"private": "Vous seul pouvez voir votre profil complet et les films que vous avez enregistrés."
+		}
 	}
 }

--- a/src/lib/locales/i18n.unit.test.ts
+++ b/src/lib/locales/i18n.unit.test.ts
@@ -12,4 +12,69 @@ describe('i18n', () => {
 		expect(i18n.hasResourceBundle('fr', 'translation')).toBe(true);
 		expect(i18n.hasResourceBundle('it', 'translation')).toBe(true);
 	});
+
+	it.each([
+		[
+			'en',
+			{
+				public: 'Public',
+				followersOnly: 'Followers only',
+				private: 'Private',
+				publicDescription: 'Anyone can view your full profile and movie logs.',
+				followersOnlyDescription:
+					'Only followers you accept can view your full profile and movie logs.',
+				privateDescription:
+					'Only you can view your full profile and movie logs.',
+			},
+		],
+		[
+			'it',
+			{
+				public: 'Pubblico',
+				followersOnly: 'Solo follower',
+				private: 'Privato',
+				publicDescription:
+					'Chiunque può vedere il tuo profilo completo e i film che hai registrato.',
+				followersOnlyDescription:
+					'Solo i follower che accetti possono vedere il tuo profilo completo e i film che hai registrato.',
+				privateDescription:
+					'Solo tu puoi vedere il tuo profilo completo e i film che hai registrato.',
+			},
+		],
+		[
+			'fr',
+			{
+				public: 'Public',
+				followersOnly: 'Abonnés uniquement',
+				private: 'Privé',
+				publicDescription:
+					'Tout le monde peut voir votre profil complet et les films que vous avez enregistrés.',
+				followersOnlyDescription:
+					'Seuls les abonnés que vous acceptez peuvent voir votre profil complet et les films que vous avez enregistrés.',
+				privateDescription:
+					'Vous seul pouvez voir votre profil complet et les films que vous avez enregistrés.',
+			},
+		],
+	])('contains complete profile visibility copy for %s', (language, copy) => {
+		expect(i18n.t('ProfileVisibilitySelect.public', { lng: language })).toBe(
+			copy.public
+		);
+		expect(
+			i18n.t('ProfileVisibilitySelect.followers_only', { lng: language })
+		).toBe(copy.followersOnly);
+		expect(i18n.t('ProfileVisibilitySelect.private', { lng: language })).toBe(
+			copy.private
+		);
+		expect(
+			i18n.t('ProfileVisibilitySelect.descriptions.public', { lng: language })
+		).toBe(copy.publicDescription);
+		expect(
+			i18n.t('ProfileVisibilitySelect.descriptions.followers_only', {
+				lng: language,
+			})
+		).toBe(copy.followersOnlyDescription);
+		expect(
+			i18n.t('ProfileVisibilitySelect.descriptions.private', { lng: language })
+		).toBe(copy.privateDescription);
+	});
 });

--- a/src/lib/locales/it.json
+++ b/src/lib/locales/it.json
@@ -339,6 +339,12 @@
 	"ProfileVisibilitySelect": {
 		"label": "Visibilità del profilo",
 		"public": "Pubblico",
-		"private": "Privato"
+		"followers_only": "Solo follower",
+		"private": "Privato",
+		"descriptions": {
+			"public": "Chiunque può vedere il tuo profilo completo e i film che hai registrato.",
+			"followers_only": "Solo i follower che accetti possono vedere il tuo profilo completo e i film che hai registrato.",
+			"private": "Solo tu puoi vedere il tuo profilo completo e i film che hai registrato."
+		}
 	}
 }

--- a/src/lib/models/profile-visibility.ts
+++ b/src/lib/models/profile-visibility.ts
@@ -1,6 +1,6 @@
 export const PROFILE_VISIBILITY_VALUES = [
 	'public',
-	'friends_only',
+	'followers_only',
 	'private',
 ] as const;
 

--- a/src/lib/models/profile-visibility.unit.test.ts
+++ b/src/lib/models/profile-visibility.unit.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import {
+	PROFILE_VISIBILITY_VALUES,
+	type ProfileVisibility,
+} from './profile-visibility';
+
+describe('profile visibility', () => {
+	it('exposes the supported wire values in display order', () => {
+		expect(PROFILE_VISIBILITY_VALUES).toEqual([
+			'public',
+			'followers_only',
+			'private',
+		]);
+	});
+
+	it('derives the profile visibility type from the supported values', () => {
+		expectTypeOf<ProfileVisibility>().toEqualTypeOf<
+			'public' | 'followers_only' | 'private'
+		>();
+	});
+});


### PR DESCRIPTION
## Summary

- replace the legacy `friends_only` profile visibility with `followers_only` across the shared type and runtime schemas
- expose Public, Followers only, and Private in registration and profile settings with accessible English, Italian, and French helper copy
- preserve the existing restricted rendering for non-public profiles and document the coordinated backend/frontend release and rollback

## Validation

- `bun run test:unit` — 721 tests passed
- `bun run test:integration` — 60 tests passed
- `bun run lint`
- `bun run build`
- `rg -n 'friends_only' src` — no matches
- React Doctor changed-scope scan — 100/100, no new issues

## Release coordination

This intentionally incompatible wire-value change must ship with [cinelog_server#195](https://github.com/benincasantonio/cinelog_server/issues/195). The repository runbook documents backend-first deployment, smoke checks, and downgrade-before-old-backend rollback.

## Screenshots

Not included; the UI change is confined to the shared visibility selector option and helper copy and is covered by component tests in both registration and profile settings.

Closes #70