### PR TITLE
test(profile): address visibility review feedback

### DIFF
--- a/docs/profile-visibility-release.md
+++ b/docs/profile-visibility-release.md
@@ -52,15 +52,10 @@ Use rollback only when roll-forward is not viable.
 
 1. Enable maintenance mode for registration and profile settings.
 2. While the new backend image that contains revision
-   `005_rename_profile_visibility` is still deployed, downgrade the database:
-
-   ```bash
-   docker compose -f docker-compose.prod.yml run --rm --no-deps db-migrate alembic downgrade 004_create_logs_table
-   docker compose -f docker-compose.prod.yml run --rm --no-deps db-migrate alembic current
-   ```
-
-3. Confirm revision `004_create_logs_table`, the reverse data conversion, and
-   the restored database constraint.
+   `005_rename_profile_visibility` is still deployed, follow the authoritative
+   backend rollback guide to downgrade the database to
+   `004_create_logs_table` and verify the current revision.
+3. Confirm the reverse data conversion and the restored database constraint.
 4. Deploy the old backend and old frontend together.
 5. Smoke-test registration and profile settings against the restored contract,
    then disable maintenance mode.

--- a/src/features/auth/components/RegistrationForm.unit.test.tsx
+++ b/src/features/auth/components/RegistrationForm.unit.test.tsx
@@ -382,11 +382,14 @@ describe('RegistrationForm', () => {
 			await act(async () => resolveRegistration!());
 		});
 
-		it('submits followers-only visibility unchanged', async () => {
+		it.each([
+			['public', 'select-public'],
+			['followers_only', 'select-followers-only'],
+		])('submits %s visibility unchanged', async (visibility, selectTestId) => {
 			mockRegister.mockResolvedValueOnce(undefined);
 			render(<RegistrationForm />);
 			fillDetails();
-			fireEvent.click(screen.getByTestId('select-followers-only'));
+			fireEvent.click(screen.getByTestId(selectTestId));
 			fireEvent.change(
 				screen.getByPlaceholderText('RegistrationForm.codePlaceholder'),
 				{ target: { value: 'ABC123' } }
@@ -399,7 +402,7 @@ describe('RegistrationForm', () => {
 
 			await waitFor(() => {
 				expect(mockRegister).toHaveBeenCalledWith(
-					expect.objectContaining({ profileVisibility: 'followers_only' })
+					expect.objectContaining({ profileVisibility: visibility })
 				);
 			});
 		});

--- a/src/features/auth/schemas/registration.schema.unit.test.ts
+++ b/src/features/auth/schemas/registration.schema.unit.test.ts
@@ -25,10 +25,9 @@ describe('createRegistrationSchema', () => {
 	});
 
 	it('rejects the legacy visibility value', () => {
-		const legacyVisibility = ['friends', 'only'].join('_');
 		const result = createRegistrationSchema(t).safeParse({
 			...validRegistration,
-			profileVisibility: legacyVisibility,
+			profileVisibility: 'friends_only',
 		});
 
 		expect(result.success).toBe(false);

--- a/src/features/profile/components/ProfileVisibilitySelect.unit.test.tsx
+++ b/src/features/profile/components/ProfileVisibilitySelect.unit.test.tsx
@@ -93,7 +93,7 @@ describe('ProfileVisibilitySelect', () => {
 		expect(screen.getAllByTestId(/^select-item-/)).toHaveLength(3);
 	});
 
-	it('should describe the selected visibility below the selector', () => {
+	it('should associate the selected visibility description with the trigger', () => {
 		render(<ProfileVisibilitySelect value="private" onChange={mockOnChange} />);
 
 		const description = screen.getByText(

--- a/src/features/profile/schemas/update-profile.schema.unit.test.ts
+++ b/src/features/profile/schemas/update-profile.schema.unit.test.ts
@@ -28,10 +28,9 @@ describe('updateProfileSchema', () => {
 	});
 
 	it('rejects the legacy visibility value', () => {
-		const legacyVisibility = ['friends', 'only'].join('_');
 		const result = schema.safeParse({
 			...validProfile,
-			profileVisibility: legacyVisibility,
+			profileVisibility: 'friends_only',
 		});
 
 		expect(result.success).toBe(false);

--- a/src/lib/locales/i18n.unit.test.ts
+++ b/src/lib/locales/i18n.unit.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from 'vitest';
+import { PROFILE_VISIBILITY_VALUES } from '@/lib/models';
 import i18n from './i18n';
+
+const SUPPORTED_LANGUAGES = ['en', 'it', 'fr'] as const;
+
+const expectNonEmptyString = (value: unknown) => {
+	expect(value).toEqual(expect.any(String));
+	if (typeof value === 'string') {
+		expect(value.trim()).not.toBe('');
+	}
+};
 
 describe('i18n', () => {
 	it('initializes translations with expected languages and fallback', () => {
@@ -13,68 +23,23 @@ describe('i18n', () => {
 		expect(i18n.hasResourceBundle('it', 'translation')).toBe(true);
 	});
 
-	it.each([
-		[
-			'en',
-			{
-				public: 'Public',
-				followersOnly: 'Followers only',
-				private: 'Private',
-				publicDescription: 'Anyone can view your full profile and movie logs.',
-				followersOnlyDescription:
-					'Only followers you accept can view your full profile and movie logs.',
-				privateDescription:
-					'Only you can view your full profile and movie logs.',
-			},
-		],
-		[
-			'it',
-			{
-				public: 'Pubblico',
-				followersOnly: 'Solo follower',
-				private: 'Privato',
-				publicDescription:
-					'Chiunque può vedere il tuo profilo completo e i film che hai registrato.',
-				followersOnlyDescription:
-					'Solo i follower che accetti possono vedere il tuo profilo completo e i film che hai registrato.',
-				privateDescription:
-					'Solo tu puoi vedere il tuo profilo completo e i film che hai registrato.',
-			},
-		],
-		[
-			'fr',
-			{
-				public: 'Public',
-				followersOnly: 'Abonnés uniquement',
-				private: 'Privé',
-				publicDescription:
-					'Tout le monde peut voir votre profil complet et les films que vous avez enregistrés.',
-				followersOnlyDescription:
-					'Seuls les abonnés que vous acceptez peuvent voir votre profil complet et les films que vous avez enregistrés.',
-				privateDescription:
-					'Vous seul pouvez voir votre profil complet et les films que vous avez enregistrés.',
-			},
-		],
-	])('contains complete profile visibility copy for %s', (language, copy) => {
-		expect(i18n.t('ProfileVisibilitySelect.public', { lng: language })).toBe(
-			copy.public
-		);
-		expect(
-			i18n.t('ProfileVisibilitySelect.followers_only', { lng: language })
-		).toBe(copy.followersOnly);
-		expect(i18n.t('ProfileVisibilitySelect.private', { lng: language })).toBe(
-			copy.private
-		);
-		expect(
-			i18n.t('ProfileVisibilitySelect.descriptions.public', { lng: language })
-		).toBe(copy.publicDescription);
-		expect(
-			i18n.t('ProfileVisibilitySelect.descriptions.followers_only', {
-				lng: language,
-			})
-		).toBe(copy.followersOnlyDescription);
-		expect(
-			i18n.t('ProfileVisibilitySelect.descriptions.private', { lng: language })
-		).toBe(copy.privateDescription);
+	it.each(
+		SUPPORTED_LANGUAGES
+	)('contains complete profile visibility copy for %s', (language) => {
+		for (const visibility of PROFILE_VISIBILITY_VALUES) {
+			const label = i18n.getResource(
+				language,
+				'translation',
+				`ProfileVisibilitySelect.${visibility}`
+			);
+			const description = i18n.getResource(
+				language,
+				'translation',
+				`ProfileVisibilitySelect.descriptions.${visibility}`
+			);
+
+			expectNonEmptyString(label);
+			expectNonEmptyString(description);
+		}
 	});
 });


### PR DESCRIPTION
## Summary

- use the literal legacy visibility value in schema rejection tests and scope the zero-reference validation to production files
- replace verbatim translation duplication with direct, non-empty locale-resource checks for every supported visibility
- restore both public and followers-only registration submission coverage and align the selector accessibility test name with its assertion
- keep rollback ordering in the frontend runbook while delegating exact commands to the authoritative backend guide

## Why

This addresses the readability, brittleness, regression-coverage, and operational-documentation feedback identified after #74 merged.

## Validation

- `bun run test:unit` — 722 tests passed
- `bun run test:integration` — 60 tests passed
- `bun run lint`
- `bun run build`
- production-only `friends_only` scan — no matches
- React Doctor changed-scope scan — 100/100, no new issues

## Screenshots

Not applicable; this follow-up changes tests and operational documentation only.

Closes #75