### PR TITLE
ci(i18n): enforce locale alignment

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,3 +24,5 @@ jobs:
       run: bun install --frozen-lockfile
     - name: Run Biome lint
       run: bun run lint
+    - name: Check locale alignment
+      run: bun run check:locales

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 		"prepare": "git config core.hooksPath .githooks",
 		"dev": "vite",
 		"build": "tsc -b tsconfig.app.json tsconfig.node.json && vite build",
+		"check:locales": "bun scripts/check-locales.ts",
 		"lint": "biome check",
 		"lint:fix": "biome check --write",
 		"preview": "vite preview",

--- a/scripts/check-locales.ts
+++ b/scripts/check-locales.ts
@@ -1,0 +1,119 @@
+import en from '../src/lib/locales/en.json';
+import fr from '../src/lib/locales/fr.json';
+import it from '../src/lib/locales/it.json';
+
+type LocaleObject = Record<string, unknown>;
+
+const isLocaleObject = (value: unknown): value is LocaleObject =>
+	typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const hasOwn = (object: LocaleObject, key: string) =>
+	Object.hasOwn(object, key);
+
+const joinPath = (parent: string, key: string) =>
+	parent.length > 0 ? `${parent}.${key}` : key;
+
+export const validateLocaleAlignment = (
+	reference: LocaleObject,
+	candidate: LocaleObject
+): string[] => {
+	const issues: string[] = [];
+
+	const compareObjects = (
+		referenceObject: LocaleObject,
+		candidateObject: LocaleObject,
+		path = ''
+	) => {
+		const referenceKeys = Object.keys(referenceObject);
+		const candidateKeys = Object.keys(candidateObject);
+
+		for (const key of referenceKeys) {
+			if (!hasOwn(candidateObject, key)) {
+				issues.push(`Missing key: ${joinPath(path, key)}`);
+			}
+		}
+
+		for (const key of candidateKeys) {
+			if (!hasOwn(referenceObject, key)) {
+				issues.push(`Unexpected key: ${joinPath(path, key)}`);
+			}
+		}
+
+		const sharedReferenceKeys = referenceKeys.filter((key) =>
+			hasOwn(candidateObject, key)
+		);
+		const sharedCandidateKeys = candidateKeys.filter((key) =>
+			hasOwn(referenceObject, key)
+		);
+
+		if (
+			sharedReferenceKeys.some(
+				(key, index) => key !== sharedCandidateKeys[index]
+			)
+		) {
+			issues.push(
+				`Key order mismatch at ${path || '<root>'}: expected [${sharedReferenceKeys.join(', ')}], received [${sharedCandidateKeys.join(', ')}]`
+			);
+		}
+
+		for (const key of sharedReferenceKeys) {
+			const keyPath = joinPath(path, key);
+			const referenceValue = referenceObject[key];
+			const candidateValue = candidateObject[key];
+
+			if (isLocaleObject(referenceValue)) {
+				if (!isLocaleObject(candidateValue)) {
+					issues.push(`Type mismatch: ${keyPath} must be an object`);
+					continue;
+				}
+
+				compareObjects(referenceValue, candidateValue, keyPath);
+				continue;
+			}
+
+			if (typeof candidateValue !== typeof referenceValue) {
+				issues.push(
+					`Type mismatch: ${keyPath} must be a ${typeof referenceValue}`
+				);
+				continue;
+			}
+
+			if (typeof candidateValue === 'string' && candidateValue.trim() === '') {
+				issues.push(`Empty value: ${keyPath}`);
+			}
+		}
+	};
+
+	compareObjects(reference, candidate);
+	return issues;
+};
+
+const locales = { en, fr, it } as const;
+
+export const checkLocales = () => {
+	let hasIssues = false;
+
+	for (const [language, locale] of Object.entries(locales)) {
+		const issues = validateLocaleAlignment(en, locale);
+
+		if (issues.length === 0) {
+			continue;
+		}
+
+		hasIssues = true;
+		process.stderr.write(
+			`Locale ${language}:\n${issues.map((issue) => `- ${issue}`).join('\n')}\n`
+		);
+	}
+
+	if (hasIssues) {
+		process.exitCode = 1;
+		return;
+	}
+
+	process.stdout.write('Locale keys and values are aligned.\n');
+};
+
+if (process.argv[1]?.endsWith('/scripts/check-locales.ts')) {
+	checkLocales();
+}

--- a/scripts/check-locales.unit.test.ts
+++ b/scripts/check-locales.unit.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { validateLocaleAlignment } from './check-locales';
+
+describe('validateLocaleAlignment', () => {
+	const reference = {
+		Section: {
+			first: 'First',
+			second: 'Second',
+		},
+	};
+
+	it('returns no issues for aligned locale data', () => {
+		expect(validateLocaleAlignment(reference, reference)).toEqual([]);
+	});
+
+	it('reports missing, unexpected, and empty locale values', () => {
+		const candidate = {
+			Section: {
+				first: '   ',
+				extra: 'Extra',
+			},
+		};
+
+		expect(validateLocaleAlignment(reference, candidate)).toEqual([
+			'Missing key: Section.second',
+			'Unexpected key: Section.extra',
+			'Empty value: Section.first',
+		]);
+	});
+
+	it('reports keys that are out of canonical order', () => {
+		const candidate = {
+			Section: {
+				second: 'Second',
+				first: 'First',
+			},
+		};
+
+		expect(validateLocaleAlignment(reference, candidate)).toEqual([
+			'Key order mismatch at Section: expected [first, second], received [second, first]',
+		]);
+	});
+
+	it('reports values whose structure does not match the reference', () => {
+		const candidate = {
+			Section: 'Not an object',
+		};
+
+		expect(validateLocaleAlignment(reference, candidate)).toEqual([
+			'Type mismatch: Section must be an object',
+		]);
+	});
+});

--- a/src/lib/locales/fr.json
+++ b/src/lib/locales/fr.json
@@ -187,7 +187,11 @@
 		"titleUpdate": "Modifier le journal",
 		"description": "Ajoutez les détails de ce que vous avez regardé.",
 		"close": "Fermer",
-		"submit": "Enregistrer"
+		"submit": "Enregistrer",
+		"submitCreate": "Enregistrer le film",
+		"submittingCreate": "Enregistrement en cours...",
+		"submitUpdate": "Mettre à jour le journal",
+		"submittingUpdate": "Mise à jour en cours..."
 	},
 	"CreateMovieLogButton": {
 		"logMovie": "Enregistrer un film"

--- a/src/lib/locales/i18n.unit.test.ts
+++ b/src/lib/locales/i18n.unit.test.ts
@@ -1,15 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { PROFILE_VISIBILITY_VALUES } from '@/lib/models';
 import i18n from './i18n';
-
-const SUPPORTED_LANGUAGES = ['en', 'it', 'fr'] as const;
-
-const expectNonEmptyString = (value: unknown) => {
-	expect(value).toEqual(expect.any(String));
-	if (typeof value === 'string') {
-		expect(value.trim()).not.toBe('');
-	}
-};
 
 describe('i18n', () => {
 	it('initializes translations with expected languages and fallback', () => {
@@ -21,25 +11,5 @@ describe('i18n', () => {
 		expect(i18n.hasResourceBundle('en', 'translation')).toBe(true);
 		expect(i18n.hasResourceBundle('fr', 'translation')).toBe(true);
 		expect(i18n.hasResourceBundle('it', 'translation')).toBe(true);
-	});
-
-	it.each(
-		SUPPORTED_LANGUAGES
-	)('contains complete profile visibility copy for %s', (language) => {
-		for (const visibility of PROFILE_VISIBILITY_VALUES) {
-			const label = i18n.getResource(
-				language,
-				'translation',
-				`ProfileVisibilitySelect.${visibility}`
-			);
-			const description = i18n.getResource(
-				language,
-				'translation',
-				`ProfileVisibilitySelect.descriptions.${visibility}`
-			);
-
-			expectNonEmptyString(label);
-			expectNonEmptyString(description);
-		}
 	});
 });

--- a/src/lib/locales/it.json
+++ b/src/lib/locales/it.json
@@ -187,7 +187,11 @@
 		"titleUpdate": "Modifica Log Film",
 		"description": "Aggiungi i dettagli di ciò che hai visto.",
 		"close": "Chiudi",
-		"submit": "Registra"
+		"submit": "Registra",
+		"submitCreate": "Registra film",
+		"submittingCreate": "Registrazione in corso...",
+		"submitUpdate": "Aggiorna log",
+		"submittingUpdate": "Aggiornamento in corso..."
 	},
 	"CreateMovieLogButton": {
 		"logMovie": "Registra Film"


### PR DESCRIPTION
## Summary

Replace the profile-specific locale completeness assertion with a repository-wide pull-request check. English is now the canonical locale structure, and CI verifies that French and Italian stay aligned with it.

## What changed

- Added `scripts/check-locales.ts`.
- Added focused unit coverage for the comparison behavior.
- Added `bun run check:locales` to the reusable lint workflow used by pull requests.
- Removed direct locale JSON assertions from `src/lib/locales/i18n.unit.test.ts`; it now tests only i18n initialization.
- Added four missing `CreateMovieLogDialog` entries to French and Italian:
  - `submitCreate`
  - `submittingCreate`
  - `submitUpdate`
  - `submittingUpdate`

## Validation contract

For every configured locale, the check recursively compares against `en.json` and fails on:

- missing keys
- unexpected keys
- empty string values
- object/value type mismatches
- shared keys in a different order

This validates project-owned locale structure. It does not test i18next, translation wording, or require translated text to match English.

## Why key order is checked

Consistent ordering keeps locale files easy to compare and review. Missing and unexpected keys are reported separately so ordering errors remain actionable rather than masking structural drift.

## Validation

- `bun run check:locales`
- `bun run test:unit` — 723 tests passed
- `bun run test:integration` — 60 tests passed
- `bun run lint` — passed with three pre-existing hook warnings
- `bun run build`
- GitHub Actions: lint, unit, integration, Playwright, Vercel, and linear-history checks passed

## Screenshots

Not applicable; this changes CI, checker tests, and locale data only.

Closes #77