### PR TITLE
feat(profile): add follow controls and relationship counts

### DIFF
--- a/src/features/auth/models/user-profile-response.ts
+++ b/src/features/auth/models/user-profile-response.ts
@@ -7,4 +7,7 @@ export type UserProfileResponse = {
 	bio?: string;
 	profileVisibility: ProfileVisibility;
 	dateOfBirth: string;
+	followerCount: number;
+	followingCount: number;
+	isFollowing: boolean;
 };

--- a/src/features/auth/repositories/user-repository.ts
+++ b/src/features/auth/repositories/user-repository.ts
@@ -16,6 +16,14 @@ export const getProfile = async (
 		.json();
 };
 
+export const followUser = async (handle: string): Promise<void> => {
+	await apiClient.put(`v1/users/${encodeURIComponent(handle)}/follow`);
+};
+
+export const unfollowUser = async (handle: string): Promise<void> => {
+	await apiClient.delete(`v1/users/${encodeURIComponent(handle)}/follow`);
+};
+
 export const updateProfile = async (
 	data: UpdateProfileRequest
 ): Promise<UserResponse> => {

--- a/src/features/auth/repositories/user-repository.unit.test.ts
+++ b/src/features/auth/repositories/user-repository.unit.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockDelete, mockGet, mockJson, mockPut } = vi.hoisted(() => ({
+	mockDelete: vi.fn(),
+	mockGet: vi.fn(),
+	mockJson: vi.fn(),
+	mockPut: vi.fn(),
+}));
+
+vi.mock('@/lib/api/client', () => ({
+	apiClient: {
+		delete: mockDelete,
+		get: mockGet,
+		put: mockPut,
+	},
+}));
+
+import { followUser, getProfile, unfollowUser } from './user-repository';
+
+describe('user repository profile requests', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockJson.mockResolvedValue(undefined);
+		mockGet.mockReturnValue({ json: mockJson });
+		mockPut.mockResolvedValue(new Response(null, { status: 204 }));
+		mockDelete.mockResolvedValue(new Response(null, { status: 204 }));
+	});
+
+	it('fetches a profile with an encoded handle', async () => {
+		await getProfile('movie fan/é');
+
+		expect(mockGet).toHaveBeenCalledWith(
+			'v1/users/movie%20fan%2F%C3%A9/profile'
+		);
+		expect(mockJson).toHaveBeenCalledOnce();
+	});
+
+	it('follows a profile without parsing the empty response', async () => {
+		await followUser('movie fan/é');
+
+		expect(mockPut).toHaveBeenCalledWith(
+			'v1/users/movie%20fan%2F%C3%A9/follow'
+		);
+		expect(mockJson).not.toHaveBeenCalled();
+	});
+
+	it('unfollows a profile without parsing the empty response', async () => {
+		await unfollowUser('movie fan/é');
+
+		expect(mockDelete).toHaveBeenCalledWith(
+			'v1/users/movie%20fan%2F%C3%A9/follow'
+		);
+		expect(mockJson).not.toHaveBeenCalled();
+	});
+});

--- a/src/features/profile/components/Profile.tsx
+++ b/src/features/profile/components/Profile.tsx
@@ -8,12 +8,14 @@ interface ProfileProps {
 	userInfo: UserProfileResponse | null;
 	isOwnProfile: boolean;
 	isPrivate: boolean;
+	onFollowStatusChange: (isFollowing: boolean) => void;
 }
 
 export const Profile = ({
 	userInfo,
 	isOwnProfile,
 	isPrivate,
+	onFollowStatusChange,
 }: ProfileProps) => {
 	const { t } = useTranslation();
 
@@ -21,7 +23,11 @@ export const Profile = ({
 		<ProfileLayout
 			sidebar={
 				<>
-					<ProfileHeader userInfo={userInfo} />
+					<ProfileHeader
+						userInfo={userInfo}
+						isOwnProfile={isOwnProfile}
+						onFollowStatusChange={onFollowStatusChange}
+					/>
 					{userInfo?.handle && !isPrivate && (
 						<ProfileMenu handle={userInfo.handle} isOwnProfile={isOwnProfile} />
 					)}

--- a/src/features/profile/components/Profile.unit.test.tsx
+++ b/src/features/profile/components/Profile.unit.test.tsx
@@ -9,6 +9,18 @@ vi.mock('react-i18next', () => ({
 	}),
 }));
 
+vi.mock('@antoniobenincasa/ui', () => ({
+	Button: ({
+		children,
+		...props
+	}: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+		<button type="button" {...props}>
+			{children}
+		</button>
+	),
+	useNotification: () => ({ notify: vi.fn() }),
+}));
+
 describe('Profile', () => {
 	const baseUserInfo = {
 		firstName: 'Neo',
@@ -16,7 +28,11 @@ describe('Profile', () => {
 		handle: 'neo',
 		dateOfBirth: '1990-01-01',
 		profileVisibility: 'public' as const,
+		followerCount: 4,
+		followingCount: 3,
+		isFollowing: false,
 	};
+	const onFollowStatusChange = vi.fn();
 
 	it('renders header, menu and outlet when user has handle', () => {
 		render(
@@ -25,6 +41,7 @@ describe('Profile', () => {
 					userInfo={baseUserInfo}
 					isOwnProfile={true}
 					isPrivate={false}
+					onFollowStatusChange={onFollowStatusChange}
 				/>
 			</MemoryRouter>
 		);
@@ -44,6 +61,7 @@ describe('Profile', () => {
 					}}
 					isOwnProfile={true}
 					isPrivate={false}
+					onFollowStatusChange={onFollowStatusChange}
 				/>
 			</MemoryRouter>
 		);
@@ -62,6 +80,7 @@ describe('Profile', () => {
 					}}
 					isOwnProfile={false}
 					isPrivate={true}
+					onFollowStatusChange={onFollowStatusChange}
 				/>
 			</MemoryRouter>
 		);
@@ -79,6 +98,7 @@ describe('Profile', () => {
 					}}
 					isOwnProfile={true}
 					isPrivate={false}
+					onFollowStatusChange={onFollowStatusChange}
 				/>
 			</MemoryRouter>
 		);

--- a/src/features/profile/components/ProfileHeader.integration.test.tsx
+++ b/src/features/profile/components/ProfileHeader.integration.test.tsx
@@ -1,0 +1,158 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockExtractApiError, mockFollowUser, mockNotify, mockUnfollowUser } =
+	vi.hoisted(() => ({
+		mockExtractApiError: vi.fn(),
+		mockFollowUser: vi.fn(),
+		mockNotify: vi.fn(),
+		mockUnfollowUser: vi.fn(),
+	}));
+
+vi.mock('@antoniobenincasa/ui', () => ({
+	Button: ({
+		children,
+		...props
+	}: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+		<button type="button" {...props}>
+			{children}
+		</button>
+	),
+	useNotification: () => ({ notify: mockNotify }),
+}));
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({
+		t: (key: string) => key,
+	}),
+}));
+
+vi.mock('lucide-react', () => ({
+	User: () => <svg data-testid="user-icon" />,
+}));
+
+vi.mock('@/features/auth/repositories/user-repository', () => ({
+	followUser: (...args: unknown[]) => mockFollowUser(...args),
+	unfollowUser: (...args: unknown[]) => mockUnfollowUser(...args),
+}));
+
+vi.mock('@/lib/api/api-error', () => ({
+	extractApiError: (...args: unknown[]) => mockExtractApiError(...args),
+}));
+
+import { ProfileHeader } from './ProfileHeader';
+
+const profile = {
+	firstName: 'John',
+	lastName: 'Doe',
+	handle: 'john doe',
+	bio: 'Movie lover',
+	profileVisibility: 'public' as const,
+	dateOfBirth: '1990-01-01',
+	followerCount: 12,
+	followingCount: 8,
+	isFollowing: false,
+};
+
+describe('ProfileHeader follow integration', () => {
+	const onFollowStatusChange = vi.fn();
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockFollowUser.mockResolvedValue(undefined);
+		mockUnfollowUser.mockResolvedValue(undefined);
+		mockExtractApiError.mockResolvedValue(null);
+	});
+
+	it('disables Follow while pending and reports success after the request resolves', async () => {
+		let resolveFollow: (() => void) | undefined;
+		mockFollowUser.mockReturnValue(
+			new Promise<void>((resolve) => {
+				resolveFollow = resolve;
+			})
+		);
+		render(
+			<ProfileHeader
+				userInfo={profile}
+				isOwnProfile={false}
+				onFollowStatusChange={onFollowStatusChange}
+			/>
+		);
+
+		const button = screen.getByRole('button', {
+			name: 'ProfileHeader.follow',
+		});
+		fireEvent.click(button);
+
+		expect(mockFollowUser).toHaveBeenCalledWith('john doe');
+		expect(button).toBeDisabled();
+		expect(button).toHaveAttribute('aria-busy', 'true');
+		expect(onFollowStatusChange).not.toHaveBeenCalled();
+
+		resolveFollow?.();
+
+		await waitFor(() =>
+			expect(onFollowStatusChange).toHaveBeenCalledWith(true)
+		);
+		expect(mockNotify).not.toHaveBeenCalled();
+		expect(button).not.toBeDisabled();
+	});
+
+	it('unfollows a preserved non-public relationship', async () => {
+		render(
+			<ProfileHeader
+				userInfo={{
+					...profile,
+					profileVisibility: 'private',
+					isFollowing: true,
+				}}
+				isOwnProfile={false}
+				onFollowStatusChange={onFollowStatusChange}
+			/>
+		);
+
+		fireEvent.click(
+			screen.getByRole('button', { name: 'ProfileHeader.unfollow' })
+		);
+
+		await waitFor(() =>
+			expect(onFollowStatusChange).toHaveBeenCalledWith(false)
+		);
+		expect(mockUnfollowUser).toHaveBeenCalledWith('john doe');
+		expect(mockNotify).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		['PROFILE_NOT_PUBLIC', 'ApiError.profileNotPublic'],
+		['RATE_LIMIT_EXCEEDED', 'ApiError.rateLimitExceeded'],
+		['UNEXPECTED_ERROR', 'ProfileHeader.followError'],
+	])('preserves state and notifies when the API returns %s', async (errorCodeName, message) => {
+		const error = new Error('Request failed');
+		mockFollowUser.mockRejectedValueOnce(error);
+		mockExtractApiError.mockResolvedValueOnce({
+			error_code_name: errorCodeName,
+		});
+		render(
+			<ProfileHeader
+				userInfo={profile}
+				isOwnProfile={false}
+				onFollowStatusChange={onFollowStatusChange}
+			/>
+		);
+
+		fireEvent.click(
+			screen.getByRole('button', { name: 'ProfileHeader.follow' })
+		);
+
+		await waitFor(() =>
+			expect(mockNotify).toHaveBeenCalledWith({
+				variant: 'danger',
+				message,
+			})
+		);
+		expect(onFollowStatusChange).not.toHaveBeenCalled();
+		expect(
+			screen.getByRole('button', { name: 'ProfileHeader.follow' })
+		).not.toBeDisabled();
+	});
+});

--- a/src/features/profile/components/ProfileHeader.tsx
+++ b/src/features/profile/components/ProfileHeader.tsx
@@ -1,13 +1,66 @@
+import { Button, useNotification } from '@antoniobenincasa/ui';
 import { User } from 'lucide-react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { UserProfileResponse } from '@/features/auth/models/user-profile-response';
+import {
+	followUser,
+	unfollowUser,
+} from '@/features/auth/repositories/user-repository';
+import { extractApiError } from '@/lib/api/api-error';
 
 interface ProfileHeaderProps {
 	userInfo: UserProfileResponse | null;
+	isOwnProfile: boolean;
+	onFollowStatusChange: (isFollowing: boolean) => void;
 }
 
-export const ProfileHeader = ({ userInfo }: ProfileHeaderProps) => {
+const FOLLOW_ERROR_KEYS: Record<string, string> = {
+	PROFILE_NOT_PUBLIC: 'ApiError.profileNotPublic',
+	RATE_LIMIT_EXCEEDED: 'ApiError.rateLimitExceeded',
+};
+
+export const ProfileHeader = ({
+	userInfo,
+	isOwnProfile,
+	onFollowStatusChange,
+}: ProfileHeaderProps) => {
 	const { t } = useTranslation();
+	const { notify } = useNotification();
+	const [isFollowPending, setIsFollowPending] = useState(false);
+
+	const showFollowControl =
+		userInfo !== null &&
+		!isOwnProfile &&
+		(userInfo.profileVisibility === 'public' || userInfo.isFollowing);
+
+	const handleFollowToggle = async () => {
+		if (!userInfo || isFollowPending) return;
+
+		setIsFollowPending(true);
+
+		try {
+			const nextIsFollowing = !userInfo.isFollowing;
+			if (nextIsFollowing) {
+				await followUser(userInfo.handle);
+			} else {
+				await unfollowUser(userInfo.handle);
+			}
+			onFollowStatusChange(nextIsFollowing);
+		} catch (error) {
+			const apiError = await extractApiError(error);
+			const messageKey =
+				(apiError?.error_code_name &&
+					FOLLOW_ERROR_KEYS[apiError.error_code_name]) ||
+				'ProfileHeader.followError';
+			notify({
+				variant: 'danger',
+				message: t(messageKey),
+			});
+		} finally {
+			setIsFollowPending(false);
+		}
+	};
 
 	return (
 		<div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-800 shadow-sm overflow-hidden">
@@ -33,6 +86,44 @@ export const ProfileHeader = ({ userInfo }: ProfileHeaderProps) => {
 					<p className="text-sm text-gray-500 dark:text-gray-400 font-medium mt-1">
 						@{userInfo.handle}
 					</p>
+				)}
+
+				{userInfo && (
+					<dl className="flex items-center justify-center gap-8 mt-4">
+						<div className="flex flex-col">
+							<dd className="text-base font-semibold text-gray-900 dark:text-white">
+								{userInfo.followerCount}
+							</dd>
+							<dt className="text-xs text-gray-500 dark:text-gray-400">
+								{t('ProfileHeader.followers')}
+							</dt>
+						</div>
+						<div className="flex flex-col">
+							<dd className="text-base font-semibold text-gray-900 dark:text-white">
+								{userInfo.followingCount}
+							</dd>
+							<dt className="text-xs text-gray-500 dark:text-gray-400">
+								{t('ProfileHeader.following')}
+							</dt>
+						</div>
+					</dl>
+				)}
+
+				{showFollowControl && (
+					<Button
+						type="button"
+						variant={userInfo.isFollowing ? 'outline' : 'default'}
+						className="w-full mt-4"
+						disabled={isFollowPending}
+						aria-busy={isFollowPending}
+						onClick={handleFollowToggle}
+					>
+						{t(
+							userInfo.isFollowing
+								? 'ProfileHeader.unfollow'
+								: 'ProfileHeader.follow'
+						)}
+					</Button>
 				)}
 
 				{/* Divider with subtle styling */}

--- a/src/features/profile/components/ProfileHeader.unit.test.tsx
+++ b/src/features/profile/components/ProfileHeader.unit.test.tsx
@@ -7,6 +7,18 @@ vi.mock('react-i18next', () => ({
 	}),
 }));
 
+vi.mock('@antoniobenincasa/ui', () => ({
+	Button: ({
+		children,
+		...props
+	}: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+		<button type="button" {...props}>
+			{children}
+		</button>
+	),
+	useNotification: () => ({ notify: vi.fn() }),
+}));
+
 vi.mock('lucide-react', () => ({
 	User: () => <svg data-testid="user-icon" />,
 }));
@@ -18,63 +30,144 @@ const fullUser = {
 	lastName: 'Doe',
 	handle: 'johndoe',
 	bio: 'Movie lover',
+	profileVisibility: 'public' as const,
+	dateOfBirth: '1990-01-01',
+	followerCount: 12,
+	followingCount: 8,
+	isFollowing: false,
 };
 
 describe('ProfileHeader', () => {
+	const onFollowStatusChange = vi.fn();
+
 	beforeEach(() => {
 		vi.clearAllMocks();
 	});
 
+	const renderHeader = (userInfo = fullUser, isOwnProfile = false) =>
+		render(
+			<ProfileHeader
+				userInfo={userInfo}
+				isOwnProfile={isOwnProfile}
+				onFollowStatusChange={onFollowStatusChange}
+			/>
+		);
+
 	it('should render the user full name', () => {
-		render(<ProfileHeader userInfo={fullUser as never} />);
+		renderHeader();
 
 		expect(screen.getByText('John Doe')).toBeInTheDocument();
 	});
 
 	it('should render the user handle with @ prefix', () => {
-		render(<ProfileHeader userInfo={fullUser as never} />);
+		renderHeader();
 
 		expect(screen.getByText('@johndoe')).toBeInTheDocument();
 	});
 
 	it('should not render the handle when it is not provided', () => {
 		const { firstName, lastName, bio } = fullUser;
-		render(<ProfileHeader userInfo={{ firstName, lastName, bio } as never} />);
+		renderHeader({ ...fullUser, firstName, lastName, handle: '', bio });
 
 		expect(screen.queryByText(/@/)).not.toBeInTheDocument();
 	});
 
 	it('should render the bio when provided', () => {
-		render(<ProfileHeader userInfo={fullUser as never} />);
+		renderHeader();
 
 		expect(screen.getByText('Movie lover')).toBeInTheDocument();
 	});
 
 	it('should render the noBio placeholder when bio is missing', () => {
 		const { firstName, lastName, handle } = fullUser;
-		render(
-			<ProfileHeader userInfo={{ firstName, lastName, handle } as never} />
-		);
+		renderHeader({ ...fullUser, firstName, lastName, handle, bio: undefined });
 
 		expect(screen.getByText('ProfileHeader.noBio')).toBeInTheDocument();
 	});
 
 	it('should render the about section heading', () => {
-		render(<ProfileHeader userInfo={fullUser as never} />);
+		renderHeader();
 
 		expect(screen.getByText('ProfileHeader.about')).toBeInTheDocument();
 	});
 
 	it('should render the user icon', () => {
-		render(<ProfileHeader userInfo={fullUser as never} />);
+		renderHeader();
 
 		expect(screen.getByTestId('user-icon')).toBeInTheDocument();
 	});
 
 	it('should handle null userInfo', () => {
-		render(<ProfileHeader userInfo={null} />);
+		render(
+			<ProfileHeader
+				userInfo={null}
+				isOwnProfile={false}
+				onFollowStatusChange={onFollowStatusChange}
+			/>
+		);
 
 		expect(screen.getByText('ProfileHeader.noBio')).toBeInTheDocument();
 		expect(screen.getByText('ProfileHeader.about')).toBeInTheDocument();
+	});
+
+	it('renders non-clickable follower and following counts', () => {
+		renderHeader();
+
+		expect(screen.getByText('12')).toBeInTheDocument();
+		expect(screen.getByText('ProfileHeader.followers')).toBeInTheDocument();
+		expect(screen.getByText('8')).toBeInTheDocument();
+		expect(screen.getByText('ProfileHeader.following')).toBeInTheDocument();
+		expect(screen.queryByRole('link')).not.toBeInTheDocument();
+	});
+
+	it('does not render a follow control on the own profile', () => {
+		renderHeader(fullUser, true);
+
+		expect(
+			screen.queryByRole('button', { name: 'ProfileHeader.follow' })
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole('button', { name: 'ProfileHeader.unfollow' })
+		).not.toBeInTheDocument();
+	});
+
+	it('renders Follow for another public profile not currently followed', () => {
+		renderHeader();
+
+		expect(
+			screen.getByRole('button', { name: 'ProfileHeader.follow' })
+		).toBeInTheDocument();
+	});
+
+	it('renders Unfollow for another public profile currently followed', () => {
+		renderHeader({ ...fullUser, isFollowing: true });
+
+		expect(
+			screen.getByRole('button', { name: 'ProfileHeader.unfollow' })
+		).toBeInTheDocument();
+	});
+
+	it.each([
+		'private',
+		'followers_only',
+	] as const)('does not render a follow control for an unrelated %s profile', (profileVisibility) => {
+		renderHeader({ ...fullUser, profileVisibility });
+
+		expect(screen.queryByRole('button')).not.toBeInTheDocument();
+	});
+
+	it.each([
+		'private',
+		'followers_only',
+	] as const)('renders Unfollow for a preserved relationship with a %s profile', (profileVisibility) => {
+		renderHeader({
+			...fullUser,
+			profileVisibility,
+			isFollowing: true,
+		});
+
+		expect(
+			screen.getByRole('button', { name: 'ProfileHeader.unfollow' })
+		).toBeInTheDocument();
 	});
 });

--- a/src/features/profile/pages/ProfilePage.tsx
+++ b/src/features/profile/pages/ProfilePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import type { UserProfileResponse } from '@/features/auth/models/user-profile-response';
 import { getProfile } from '@/features/auth/repositories/user-repository';
@@ -19,22 +19,56 @@ const ProfilePage = () => {
 	const isOwnProfile = userInfo?.handle === handle;
 
 	useEffect(() => {
-		if (!handle || isOwnProfile || isUserInfoLoading) return;
+		if (!handle || isUserInfoLoading) return;
+
+		let isActive = true;
 
 		setIsProfileLoading(true);
 		setNotFound(false);
+		setProfileData(null);
 		getProfile(handle)
-			.then(setProfileData)
+			.then((profile) => {
+				if (isActive) {
+					setProfileData(profile);
+				}
+			})
 			.catch(async (err) => {
 				const apiError = await extractApiError(err);
+				if (!isActive) return;
+
 				if (apiError?.error_code_name === 'USER_NOT_FOUND') {
 					setNotFound(true);
 				} else {
 					setProfileData(null);
 				}
 			})
-			.finally(() => setIsProfileLoading(false));
-	}, [handle, isOwnProfile, isUserInfoLoading]);
+			.finally(() => {
+				if (isActive) {
+					setIsProfileLoading(false);
+				}
+			});
+
+		return () => {
+			isActive = false;
+		};
+	}, [handle, isUserInfoLoading]);
+
+	const handleFollowStatusChange = useCallback((isFollowing: boolean) => {
+		setProfileData((currentProfile) => {
+			if (!currentProfile || currentProfile.isFollowing === isFollowing) {
+				return currentProfile;
+			}
+
+			return {
+				...currentProfile,
+				followerCount: Math.max(
+					0,
+					currentProfile.followerCount + (isFollowing ? 1 : -1)
+				),
+				isFollowing,
+			};
+		});
+	}, []);
 
 	if (isUserInfoLoading || isProfileLoading) {
 		return <ProfileLoading />;
@@ -48,12 +82,6 @@ const ProfilePage = () => {
 		return <ProfileNotFoundPage />;
 	}
 
-	if (isOwnProfile) {
-		return (
-			<Profile userInfo={userInfo} isOwnProfile={true} isPrivate={false} />
-		);
-	}
-
 	if (!profileData) {
 		return null;
 	}
@@ -61,8 +89,9 @@ const ProfilePage = () => {
 	return (
 		<Profile
 			userInfo={profileData}
-			isOwnProfile={false}
-			isPrivate={profileData.profileVisibility !== 'public'}
+			isOwnProfile={isOwnProfile}
+			isPrivate={!isOwnProfile && profileData.profileVisibility !== 'public'}
+			onFollowStatusChange={handleFollowStatusChange}
 		/>
 	);
 };

--- a/src/features/profile/pages/ProfilePage.unit.test.tsx
+++ b/src/features/profile/pages/ProfilePage.unit.test.tsx
@@ -1,4 +1,10 @@
-import { act, render, screen, waitFor } from '@testing-library/react';
+import {
+	act,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import ProfilePage from './ProfilePage';
@@ -24,14 +30,27 @@ vi.mock('../components', () => ({
 		userInfo,
 		isOwnProfile,
 		isPrivate,
+		onFollowStatusChange,
 	}: {
-		userInfo: unknown;
+		userInfo: {
+			followerCount: number;
+			isFollowing: boolean;
+		} | null;
 		isOwnProfile: boolean;
 		isPrivate: boolean;
+		onFollowStatusChange: (isFollowing: boolean) => void;
 	}) => (
-		<div data-testid="profile">
-			{JSON.stringify({ userInfo, isOwnProfile, isPrivate })}
-		</div>
+		<>
+			<div data-testid="profile">
+				{JSON.stringify({ userInfo, isOwnProfile, isPrivate })}
+			</div>
+			<button type="button" onClick={() => onFollowStatusChange(true)}>
+				mark-following
+			</button>
+			<button type="button" onClick={() => onFollowStatusChange(false)}>
+				mark-not-following
+			</button>
+		</>
 	),
 	ProfileLoading: () => <div data-testid="profile-loading">Loading</div>,
 }));
@@ -75,20 +94,33 @@ describe('ProfilePage', () => {
 		expect(screen.queryByTestId('profile')).not.toBeInTheDocument();
 	});
 
-	it('renders own profile using auth store data', async () => {
+	it('fetches and renders the own profile response with relationship counts', async () => {
+		const ownProfile = {
+			firstName: 'Neo',
+			lastName: 'Anderson',
+			handle: 'neo',
+			dateOfBirth: '1990-01-01',
+			profileVisibility: 'private' as const,
+			followerCount: 7,
+			followingCount: 5,
+			isFollowing: false,
+		};
 		mockUseAuthStore.mockReturnValue({
 			userInfo: ownUserInfo,
 			isUserInfoLoading: false,
 		});
+		mockGetProfile.mockResolvedValueOnce(ownProfile);
 
-		await act(() => {
-			renderWithRouter('neo');
-		});
+		renderWithRouter('neo');
 
-		expect(screen.getByTestId('profile')).toBeInTheDocument();
+		await waitFor(() =>
+			expect(screen.getByTestId('profile')).toBeInTheDocument()
+		);
+
+		expect(mockGetProfile).toHaveBeenCalledWith('neo');
 		expect(screen.getByTestId('profile')).toHaveTextContent(
 			JSON.stringify({
-				userInfo: ownUserInfo,
+				userInfo: ownProfile,
 				isOwnProfile: true,
 				isPrivate: false,
 			})
@@ -102,6 +134,9 @@ describe('ProfilePage', () => {
 			handle: 'morpheus',
 			dateOfBirth: '',
 			profileVisibility: 'public',
+			followerCount: 2,
+			followingCount: 4,
+			isFollowing: false,
 		};
 
 		mockUseAuthStore.mockReturnValue({
@@ -133,6 +168,9 @@ describe('ProfilePage', () => {
 			handle: 'trinity',
 			dateOfBirth: '1988-08-08',
 			profileVisibility: 'private',
+			followerCount: 3,
+			followingCount: 1,
+			isFollowing: false,
 		};
 
 		mockUseAuthStore.mockReturnValue({
@@ -163,6 +201,9 @@ describe('ProfilePage', () => {
 			handle: 'oracle',
 			dateOfBirth: '',
 			profileVisibility: 'followers_only',
+			followerCount: 8,
+			followingCount: 6,
+			isFollowing: true,
 		};
 
 		mockUseAuthStore.mockReturnValue({
@@ -183,6 +224,54 @@ describe('ProfilePage', () => {
 				isOwnProfile: false,
 				isPrivate: true,
 			})
+		);
+	});
+
+	it('updates follower state and count exactly once per status transition', async () => {
+		const otherProfile = {
+			firstName: 'Morpheus',
+			lastName: 'Leader',
+			handle: 'morpheus',
+			dateOfBirth: '',
+			profileVisibility: 'public',
+			followerCount: 2,
+			followingCount: 4,
+			isFollowing: false,
+		};
+		mockUseAuthStore.mockReturnValue({
+			userInfo: ownUserInfo,
+			isUserInfoLoading: false,
+		});
+		mockGetProfile.mockResolvedValueOnce(otherProfile);
+
+		renderWithRouter('morpheus');
+
+		await waitFor(() =>
+			expect(screen.getByTestId('profile')).toHaveTextContent(
+				'"followerCount":2'
+			)
+		);
+
+		fireEvent.click(screen.getByRole('button', { name: 'mark-following' }));
+
+		expect(screen.getByTestId('profile')).toHaveTextContent(
+			'"followerCount":3'
+		);
+		expect(screen.getByTestId('profile')).toHaveTextContent(
+			'"isFollowing":true'
+		);
+
+		fireEvent.click(screen.getByRole('button', { name: 'mark-following' }));
+		expect(screen.getByTestId('profile')).toHaveTextContent(
+			'"followerCount":3'
+		);
+
+		fireEvent.click(screen.getByRole('button', { name: 'mark-not-following' }));
+		expect(screen.getByTestId('profile')).toHaveTextContent(
+			'"followerCount":2'
+		);
+		expect(screen.getByTestId('profile')).toHaveTextContent(
+			'"isFollowing":false'
 		);
 	});
 

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -47,7 +47,12 @@
 	},
 	"ProfileHeader": {
 		"about": "About",
-		"noBio": "No bio available."
+		"noBio": "No bio available.",
+		"followers": "Followers",
+		"following": "Following",
+		"follow": "Follow",
+		"unfollow": "Unfollow",
+		"followError": "Unable to update this follow. Please try again."
 	},
 	"ProfileMenu": {
 		"overview": "Overview",

--- a/src/lib/locales/fr.json
+++ b/src/lib/locales/fr.json
@@ -47,7 +47,12 @@
 	},
 	"ProfileHeader": {
 		"about": "À propos",
-		"noBio": "Aucune bio disponible."
+		"noBio": "Aucune bio disponible.",
+		"followers": "Abonnés",
+		"following": "Abonnements",
+		"follow": "Suivre",
+		"unfollow": "Ne plus suivre",
+		"followError": "Impossible de mettre à jour cet abonnement. Veuillez réessayer."
 	},
 	"ProfileMenu": {
 		"overview": "Aperçu",

--- a/src/lib/locales/it.json
+++ b/src/lib/locales/it.json
@@ -47,7 +47,12 @@
 	},
 	"ProfileHeader": {
 		"about": "Informazioni",
-		"noBio": "Nessuna biografia disponibile."
+		"noBio": "Nessuna biografia disponibile.",
+		"followers": "Follower",
+		"following": "Seguiti",
+		"follow": "Segui",
+		"unfollow": "Non seguire più",
+		"followError": "Impossibile aggiornare questo follow. Riprova."
 	},
 	"ProfileMenu": {
 		"overview": "Panoramica",


### PR DESCRIPTION
## Summary

- add typed follow and unfollow API requests plus profile relationship fields
- show follower/following counts and visibility-aware Follow/Unfollow controls in the profile header
- fetch the profile endpoint for own profiles so relationship counts are available
- preserve relationship state on failures and surface localized notifications
- add co-located unit and integration coverage for repository, profile state, visibility, pending, success, and error behavior

## Why

The server now exposes basic directional public-profile following and relationship counts. The web client needs to consume that contract while preserving the existing restrictions for non-public profiles.

## User and developer impact

- users can follow and unfollow public profiles from the profile header
- users can always unfollow preserved relationships after a target becomes non-public
- counts remain visible across all profile visibility modes
- own profiles show counts but never show a follow control
- mutations remain non-optimistic and use the existing authentication, CSRF, and notification infrastructure
- the existing alpha profile-visibility copy remains unchanged

## Validation

- `bun run test:unit` — 735 passed
- `bun run test:integration` — 65 passed
- `bun run check:locales`
- `bun run lint`
- `bun run build`

## Dependencies

- Server issue: https://github.com/benincasantonio/cinelog_server/issues/211
- Server PR: https://github.com/benincasantonio/cinelog_server/pull/212

## Screenshots

Not included because populated follow state depends on the server changes in PR #212.

Closes #79
