### PR TITLE
feat(i18n): persist account locale and send Accept-Language

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository contains the web frontend for Cinelog. The project already lets 
 
 - Authentication flows: login, registration, forgot password, and reset password
 - Movie search and movie details
+- Account-backed English, French, and Italian localization
 - Watched movie logging
 - Tracking where a movie was watched
 - Profile pages

--- a/src/features/auth/components/RegistrationForm.tsx
+++ b/src/features/auth/components/RegistrationForm.tsx
@@ -16,6 +16,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { ProfileVisibilitySelect } from '@/features/profile/components/ProfileVisibilitySelect';
 import { extractApiError, resolveApiFieldError } from '@/lib/api/api-error';
+import { getActiveLocale } from '@/lib/locales/i18n';
 import type { ProfileVisibility } from '@/lib/models';
 import {
 	CODE_LENGTH,
@@ -116,6 +117,7 @@ export const RegistrationForm = () => {
 				handle: data.handle,
 				dateOfBirth: data.dateOfBirth.toISOString().split('T')[0],
 				bio: data.bio,
+				locale: getActiveLocale(),
 				profileVisibility: data.profileVisibility,
 				verificationCode: data.verificationCode,
 			});

--- a/src/features/auth/components/RegistrationForm.unit.test.tsx
+++ b/src/features/auth/components/RegistrationForm.unit.test.tsx
@@ -13,6 +13,10 @@ vi.mock('react-i18next', () => ({
 	}),
 }));
 
+vi.mock('@/lib/locales/i18n', () => ({
+	getActiveLocale: () => 'fr-FR',
+}));
+
 const mockNavigate = vi.fn();
 vi.mock('react-router-dom', () => ({
 	useNavigate: () => mockNavigate,
@@ -353,6 +357,7 @@ describe('RegistrationForm', () => {
 						email: 'john@example.com',
 						password: 'password123',
 						handle: 'johndoe',
+						locale: 'fr-FR',
 						profileVisibility: 'private',
 						verificationCode: 'A1B2C3',
 					})

--- a/src/features/auth/models/auth-responses.ts
+++ b/src/features/auth/models/auth-responses.ts
@@ -1,18 +1,21 @@
-export interface LoginResponse {
+import type { Locale } from '@/lib/models';
+
+export type LoginResponse = {
 	userId: string;
 	email: string;
 	firstName: string;
 	lastName: string;
 	handle: string;
 	bio: string | null;
+	locale: Locale;
 	csrfToken: string;
-}
+};
 
-export interface RefreshResponse {
+export type RefreshResponse = {
 	message: string;
 	csrfToken: string;
-}
+};
 
-export interface CsrfTokenResponse {
+export type CsrfTokenResponse = {
 	csrfToken: string;
-}
+};

--- a/src/features/auth/models/forgot-password.ts
+++ b/src/features/auth/models/forgot-password.ts
@@ -3,6 +3,6 @@
  *
  * Triggers sending a password reset code to the specified email address.
  */
-export interface ForgotPasswordRequest {
+export type ForgotPasswordRequest = {
 	email: string;
-}
+};

--- a/src/features/auth/models/index.ts
+++ b/src/features/auth/models/index.ts
@@ -1,0 +1,15 @@
+export type {
+	CsrfTokenResponse,
+	LoginResponse,
+	RefreshResponse,
+} from './auth-responses';
+export type { ForgotPasswordRequest } from './forgot-password';
+export type { RegisterRequest } from './register-request';
+export type { ResetPasswordRequest } from './reset-password';
+export type { SendCodeRequest } from './send-code-request';
+export type {
+	UpdateLocaleRequest,
+	UpdateLocaleResponse,
+} from './update-locale';
+export type { UserProfileResponse } from './user-profile-response';
+export type { UserResponse } from './user-response';

--- a/src/features/auth/models/register-request.ts
+++ b/src/features/auth/models/register-request.ts
@@ -1,4 +1,4 @@
-import type { ProfileVisibility } from '@/lib/models';
+import type { Locale, ProfileVisibility } from '@/lib/models';
 
 export type RegisterRequest = {
 	firstName: string;
@@ -8,6 +8,7 @@ export type RegisterRequest = {
 	handle: string;
 	dateOfBirth: string;
 	bio?: string;
+	locale: Locale;
 	profileVisibility: ProfileVisibility;
 	verificationCode: string;
 };

--- a/src/features/auth/models/reset-password.ts
+++ b/src/features/auth/models/reset-password.ts
@@ -3,8 +3,8 @@
  *
  * Resets the user's password using the code received via email.
  */
-export interface ResetPasswordRequest {
+export type ResetPasswordRequest = {
 	email: string;
 	code: string;
 	new_password: string;
-}
+};

--- a/src/features/auth/models/update-locale.ts
+++ b/src/features/auth/models/update-locale.ts
@@ -1,0 +1,9 @@
+import type { Locale } from '@/lib/models';
+
+export type UpdateLocaleRequest = {
+	locale: Locale;
+};
+
+export type UpdateLocaleResponse = {
+	locale: Locale;
+};

--- a/src/features/auth/models/user-response.ts
+++ b/src/features/auth/models/user-response.ts
@@ -1,4 +1,4 @@
-import type { ProfileVisibility } from '@/lib/models';
+import type { Locale, ProfileVisibility } from '@/lib/models';
 
 export type UserResponse = {
 	id: string;
@@ -8,5 +8,6 @@ export type UserResponse = {
 	handle: string;
 	dateOfBirth: string;
 	bio?: string;
+	locale: Locale;
 	profileVisibility: ProfileVisibility;
 };

--- a/src/features/auth/repositories/auth-repository.ts
+++ b/src/features/auth/repositories/auth-repository.ts
@@ -1,4 +1,5 @@
 import { apiClient } from '@/lib/api/client';
+import { getActiveLocale } from '@/lib/locales/i18n';
 import type { ApiClientOptions } from '@/lib/models/api-client-options';
 import type {
 	CsrfTokenResponse,
@@ -18,6 +19,7 @@ import type { SendCodeRequest } from '../models/send-code-request';
 export const fetchCsrfToken = async (): Promise<CsrfTokenResponse> => {
 	const response = await fetch(`${import.meta.env.VITE_API_URL}v1/auth/csrf`, {
 		credentials: 'include',
+		headers: { 'Accept-Language': getActiveLocale() },
 	});
 	if (!response.ok) {
 		throw new Error(
@@ -54,6 +56,7 @@ export const refreshToken = async (): Promise<RefreshResponse> => {
 		{
 			method: 'POST',
 			credentials: 'include',
+			headers: { 'Accept-Language': getActiveLocale() },
 		}
 	);
 

--- a/src/features/auth/repositories/auth-repository.unit.test.ts
+++ b/src/features/auth/repositories/auth-repository.unit.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { mockJson, mockPost } = vi.hoisted(() => ({
 	mockJson: vi.fn(),
@@ -11,13 +11,35 @@ vi.mock('@/lib/api/client', () => ({
 	},
 }));
 
-import { register, sendRegistrationCode } from './auth-repository';
+vi.mock('@/lib/locales/i18n', () => ({
+	getActiveLocale: () => 'it-IT',
+}));
+
+import {
+	fetchCsrfToken,
+	refreshToken,
+	register,
+	sendRegistrationCode,
+} from './auth-repository';
 
 describe('auth repository registration requests', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockJson.mockResolvedValue(undefined);
 		mockPost.mockReturnValue({ json: mockJson });
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(
+				new Response(JSON.stringify({ csrfToken: 'csrf-token' }), {
+					status: 200,
+					headers: { 'Content-Type': 'application/json' },
+				})
+			)
+		);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
 	});
 
 	it('does not retry registration because errors are structured and the request creates state', async () => {
@@ -28,6 +50,7 @@ describe('auth repository registration requests', () => {
 			password: 'password123',
 			handle: 'johndoe',
 			dateOfBirth: '2000-01-01',
+			locale: 'it-IT' as const,
 			profileVisibility: 'private' as const,
 			verificationCode: 'ABC123',
 		};
@@ -39,6 +62,31 @@ describe('auth repository registration requests', () => {
 			skipAuth: true,
 			retry: 0,
 		});
+	});
+
+	it('sends the active locale when fetching a CSRF token', async () => {
+		await fetchCsrfToken();
+
+		expect(fetch).toHaveBeenCalledWith(
+			expect.stringContaining('v1/auth/csrf'),
+			{
+				credentials: 'include',
+				headers: { 'Accept-Language': 'it-IT' },
+			}
+		);
+	});
+
+	it('sends the active locale when refreshing authentication', async () => {
+		await refreshToken();
+
+		expect(fetch).toHaveBeenCalledWith(
+			expect.stringContaining('v1/auth/refresh'),
+			{
+				method: 'POST',
+				credentials: 'include',
+				headers: { 'Accept-Language': 'it-IT' },
+			}
+		);
 	});
 
 	it('does not retry sending a registration code', async () => {

--- a/src/features/auth/repositories/user-repository.ts
+++ b/src/features/auth/repositories/user-repository.ts
@@ -1,6 +1,11 @@
 import type { ChangePasswordRequest } from '@/features/profile/models/change-password-request';
 import type { UpdateProfileRequest } from '@/features/profile/models/update-profile-request';
 import { apiClient } from '@/lib/api/client';
+import type { Locale } from '@/lib/models';
+import type {
+	UpdateLocaleRequest,
+	UpdateLocaleResponse,
+} from '../models/update-locale';
 import type { UserProfileResponse } from '../models/user-profile-response';
 import type { UserResponse } from '../models/user-response';
 
@@ -22,6 +27,31 @@ export const followUser = async (handle: string): Promise<void> => {
 
 export const unfollowUser = async (handle: string): Promise<void> => {
 	await apiClient.delete(`v1/users/${encodeURIComponent(handle)}/follow`);
+};
+
+export const updateLocale = async (
+	locale: Locale
+): Promise<UpdateLocaleResponse> => {
+	const request: UpdateLocaleRequest = { locale };
+	const response = await apiClient.put('v1/users/settings/locale', {
+		json: request,
+	});
+
+	try {
+		const body: unknown = await response.json();
+		if (
+			typeof body === 'object' &&
+			body !== null &&
+			'locale' in body &&
+			typeof body.locale === 'string'
+		) {
+			return { locale: body.locale as Locale };
+		}
+	} catch {
+		// A successful PUT may still have an empty or malformed response body.
+	}
+
+	return { locale };
 };
 
 export const updateProfile = async (

--- a/src/features/auth/repositories/user-repository.unit.test.ts
+++ b/src/features/auth/repositories/user-repository.unit.test.ts
@@ -15,14 +15,19 @@ vi.mock('@/lib/api/client', () => ({
 	},
 }));
 
-import { followUser, getProfile, unfollowUser } from './user-repository';
+import {
+	followUser,
+	getProfile,
+	unfollowUser,
+	updateLocale,
+} from './user-repository';
 
 describe('user repository profile requests', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockJson.mockResolvedValue(undefined);
 		mockGet.mockReturnValue({ json: mockJson });
-		mockPut.mockResolvedValue(new Response(null, { status: 204 }));
+		mockPut.mockReturnValue({ json: mockJson });
 		mockDelete.mockResolvedValue(new Response(null, { status: 204 }));
 	});
 
@@ -41,6 +46,40 @@ describe('user repository profile requests', () => {
 		expect(mockPut).toHaveBeenCalledWith(
 			'v1/users/movie%20fan%2F%C3%A9/follow'
 		);
+		expect(mockJson).not.toHaveBeenCalled();
+	});
+
+	it('updates and returns the saved account locale', async () => {
+		mockJson.mockResolvedValueOnce({ locale: 'fr-FR' });
+
+		await expect(updateLocale('fr-FR')).resolves.toEqual({
+			locale: 'fr-FR',
+		});
+
+		expect(mockPut).toHaveBeenCalledWith('v1/users/settings/locale', {
+			json: { locale: 'fr-FR' },
+		});
+		expect(mockJson).toHaveBeenCalledOnce();
+	});
+
+	it('falls back to the requested locale when the success body is not valid JSON', async () => {
+		mockJson.mockRejectedValueOnce(
+			new SyntaxError('Unexpected end of JSON input')
+		);
+
+		await expect(updateLocale('it-IT')).resolves.toEqual({ locale: 'it-IT' });
+	});
+
+	it('falls back to the requested locale when the success body is null', async () => {
+		mockJson.mockResolvedValueOnce(null);
+
+		await expect(updateLocale('fr-FR')).resolves.toEqual({ locale: 'fr-FR' });
+	});
+
+	it('does not treat a failed locale request as a successful update', async () => {
+		mockPut.mockRejectedValueOnce(new Error('HTTP 500'));
+
+		await expect(updateLocale('fr-FR')).rejects.toThrow('HTTP 500');
 		expect(mockJson).not.toHaveBeenCalled();
 	});
 

--- a/src/features/auth/stores/useAuthStore.ts
+++ b/src/features/auth/stores/useAuthStore.ts
@@ -6,16 +6,23 @@ import {
 	register,
 	sendRegistrationCode,
 } from '@/features/auth/repositories/auth-repository';
+import { changeActiveLocale, getActiveLocale } from '@/lib/locales/i18n';
+import type { Locale } from '@/lib/models';
+import { resolveSupportedLocale } from '@/lib/utilities/locale-utils';
 import type { RegisterRequest } from '../models/register-request';
 import type { SendCodeRequest } from '../models/send-code-request';
 import type { UserResponse } from '../models/user-response';
-import { getUserInfo } from '../repositories/user-repository';
+import {
+	getUserInfo,
+	updateLocale as persistLocale,
+} from '../repositories/user-repository';
 
 export const useAuthStore = create<{
 	isInitialized: boolean;
 	csrfToken: string | null;
 	userInfo: UserResponse | null;
 	isUserInfoLoading: boolean;
+	isLocaleUpdating: boolean;
 	authenticatedStatus: boolean | null;
 	setAuthenticatedStatus: (status: boolean | null) => void;
 	setCsrfToken: (csrfToken: string | null) => void;
@@ -25,12 +32,14 @@ export const useAuthStore = create<{
 	sendRegistrationCode: (request: SendCodeRequest) => Promise<void>;
 	fetchUserInfo: () => Promise<void>;
 	updateUserInfo: (userInfo: UserResponse) => void;
+	updateLocale: (locale: Locale) => Promise<void>;
 }>((set, get) => ({
 	isInitialized: false,
 	csrfToken: null,
 	userInfo: null,
 	authenticatedStatus: null,
 	isUserInfoLoading: false,
+	isLocaleUpdating: false,
 	setAuthenticatedStatus: (status: boolean | null) =>
 		set({ authenticatedStatus: status }),
 	setCsrfToken: (csrfToken: string | null) => set({ csrfToken }),
@@ -48,7 +57,12 @@ export const useAuthStore = create<{
 	logout: async () => {
 		try {
 			await logout();
-			set({ authenticatedStatus: false, userInfo: null, csrfToken: null });
+			set({
+				authenticatedStatus: false,
+				userInfo: null,
+				csrfToken: null,
+				isLocaleUpdating: false,
+			});
 		} catch (error) {
 			console.error(error);
 		}
@@ -70,15 +84,59 @@ export const useAuthStore = create<{
 		}
 	},
 	updateUserInfo: (userInfo: UserResponse) => set({ userInfo }),
+	updateLocale: async (locale: Locale) => {
+		const { isLocaleUpdating, userInfo } = get();
+		if (!userInfo || isLocaleUpdating || userInfo.locale === locale) return;
+
+		set({ isLocaleUpdating: true });
+		try {
+			const response = await persistLocale(locale);
+			const savedLocale = resolveSupportedLocale(response.locale);
+			if (!savedLocale) {
+				console.error(
+					'The locale update response was not supported; applying the requested locale'
+				);
+			}
+
+			// The PUT already persisted `locale` server-side by this point, so an
+			// unparseable response body must fall back to it rather than throw —
+			// throwing here would report a successful write as a failed update.
+			const nextLocale = savedLocale ?? locale;
+
+			await changeActiveLocale(nextLocale);
+			set((state) => ({
+				userInfo: state.userInfo
+					? { ...state.userInfo, locale: nextLocale }
+					: null,
+			}));
+		} catch (error) {
+			console.error(error);
+			throw error;
+		} finally {
+			set({ isLocaleUpdating: false });
+		}
+	},
 	fetchUserInfo: async () => {
 		set({ isUserInfoLoading: true });
 		try {
 			const userInfo = await getUserInfo();
+			const detectedLocale = getActiveLocale();
+			const accountLocale = resolveSupportedLocale(
+				(userInfo as { locale?: unknown }).locale
+			);
+			if (!accountLocale) {
+				console.error(
+					'The account response did not include a supported locale; using the detected fallback'
+				);
+			}
+			const activeLocale = accountLocale ?? detectedLocale;
+
+			await changeActiveLocale(activeLocale);
 			const csrfResponse = await fetchCsrfToken();
 			const csrfToken = csrfResponse.csrfToken;
 
 			set({
-				userInfo,
+				userInfo: { ...userInfo, locale: activeLocale },
 				authenticatedStatus: true,
 				csrfToken,
 				isInitialized: true,
@@ -89,6 +147,7 @@ export const useAuthStore = create<{
 				authenticatedStatus: false,
 				userInfo: null,
 				csrfToken: null,
+				isLocaleUpdating: false,
 				isInitialized: true,
 			});
 		} finally {

--- a/src/features/auth/stores/useAuthStore.unit.test.ts
+++ b/src/features/auth/stores/useAuthStore.unit.test.ts
@@ -14,6 +14,9 @@ const {
 	mockSendRegistrationCode,
 	mockFetchCsrfToken,
 	mockGetUserInfo,
+	mockUpdateLocale,
+	mockChangeLanguage,
+	mockGetActiveLocale,
 } = vi.hoisted(() => ({
 	mockLogin: vi.fn(),
 	mockLogout: vi.fn(),
@@ -21,6 +24,9 @@ const {
 	mockSendRegistrationCode: vi.fn(),
 	mockFetchCsrfToken: vi.fn(),
 	mockGetUserInfo: vi.fn(),
+	mockUpdateLocale: vi.fn(),
+	mockChangeLanguage: vi.fn(),
+	mockGetActiveLocale: vi.fn(),
 }));
 
 vi.mock('@/features/auth/repositories/auth-repository', () => ({
@@ -33,6 +39,12 @@ vi.mock('@/features/auth/repositories/auth-repository', () => ({
 
 vi.mock('../repositories/user-repository', () => ({
 	getUserInfo: mockGetUserInfo,
+	updateLocale: mockUpdateLocale,
+}));
+
+vi.mock('@/lib/locales/i18n', () => ({
+	changeActiveLocale: mockChangeLanguage,
+	getActiveLocale: mockGetActiveLocale,
 }));
 
 // ---------------------------------------------------------------------------
@@ -53,6 +65,7 @@ const mockUser = {
 	handle: 'johndoe',
 	dateOfBirth: '1990-01-01',
 	bio: 'A test user',
+	locale: 'en-US' as const,
 };
 
 const mockLoginResponse = {
@@ -62,6 +75,7 @@ const mockLoginResponse = {
 	lastName: 'Doe',
 	handle: 'johndoe',
 	bio: null,
+	locale: 'en-US' as const,
 	csrfToken: 'login-csrf-token',
 };
 
@@ -74,6 +88,7 @@ const mockRegisterRequest = {
 	password: 'secret',
 	handle: 'janedoe',
 	dateOfBirth: '1992-05-15',
+	locale: 'fr-FR' as const,
 };
 
 // ---------------------------------------------------------------------------
@@ -90,6 +105,7 @@ function resetStore() {
 		csrfToken: null,
 		userInfo: null,
 		isUserInfoLoading: false,
+		isLocaleUpdating: false,
 		authenticatedStatus: null,
 	});
 }
@@ -107,6 +123,8 @@ describe('useAuthStore', () => {
 			.mockImplementation(() => undefined);
 		vi.clearAllMocks();
 		resetStore();
+		mockChangeLanguage.mockResolvedValue(undefined);
+		mockGetActiveLocale.mockReturnValue('en-US');
 	});
 
 	afterEach(() => {
@@ -125,6 +143,7 @@ describe('useAuthStore', () => {
 			expect(state.csrfToken).toBeNull();
 			expect(state.userInfo).toBeNull();
 			expect(state.isUserInfoLoading).toBe(false);
+			expect(state.isLocaleUpdating).toBe(false);
 			expect(state.authenticatedStatus).toBeNull();
 		});
 	});
@@ -523,6 +542,9 @@ describe('useAuthStore', () => {
 				callOrder.push('getUserInfo');
 				return mockUser;
 			});
+			mockChangeLanguage.mockImplementationOnce(async () => {
+				callOrder.push('changeLanguage');
+			});
 			mockFetchCsrfToken.mockImplementationOnce(async () => {
 				callOrder.push('fetchCsrfToken');
 				return mockCsrfResponse;
@@ -530,7 +552,135 @@ describe('useAuthStore', () => {
 
 			await useAuthStore.getState().fetchUserInfo();
 
-			expect(callOrder).toEqual(['getUserInfo', 'fetchCsrfToken']);
+			expect(callOrder).toEqual([
+				'getUserInfo',
+				'changeLanguage',
+				'fetchCsrfToken',
+			]);
+			expect(mockChangeLanguage).toHaveBeenCalledWith('en-US');
+		});
+
+		it('waits for the account locale before completing initialization', async () => {
+			let resolveLanguage: (() => void) | undefined;
+			mockGetUserInfo.mockResolvedValueOnce({
+				...mockUser,
+				locale: 'fr-FR',
+			});
+			mockChangeLanguage.mockReturnValueOnce(
+				new Promise<void>((resolve) => {
+					resolveLanguage = resolve;
+				})
+			);
+			mockFetchCsrfToken.mockResolvedValueOnce(mockCsrfResponse);
+
+			const fetchPromise = useAuthStore.getState().fetchUserInfo();
+			await vi.waitFor(() =>
+				expect(mockChangeLanguage).toHaveBeenCalledWith('fr-FR')
+			);
+
+			expect(useAuthStore.getState().isInitialized).toBe(false);
+
+			resolveLanguage?.();
+			await fetchPromise;
+
+			expect(useAuthStore.getState().isInitialized).toBe(true);
+			expect(useAuthStore.getState().userInfo?.locale).toBe('fr-FR');
+		});
+
+		it('keeps the session and detector fallback for an invalid account locale', async () => {
+			mockGetActiveLocale.mockReturnValueOnce('it-IT');
+			mockGetUserInfo.mockResolvedValueOnce({
+				...mockUser,
+				locale: 'de-DE',
+			});
+			mockFetchCsrfToken.mockResolvedValueOnce(mockCsrfResponse);
+
+			await useAuthStore.getState().fetchUserInfo();
+
+			expect(mockChangeLanguage).toHaveBeenCalledWith('it-IT');
+			expect(useAuthStore.getState().authenticatedStatus).toBe(true);
+			expect(useAuthStore.getState().userInfo?.locale).toBe('it-IT');
+			expect(consoleErrorSpy).toHaveBeenCalled();
+		});
+	});
+
+	describe('updateLocale', () => {
+		it('persists before changing i18n and account state', async () => {
+			const callOrder: string[] = [];
+			useAuthStore.setState({ userInfo: mockUser });
+			mockUpdateLocale.mockImplementationOnce(async () => {
+				callOrder.push('updateLocale');
+				return { locale: 'fr-FR' };
+			});
+			mockChangeLanguage.mockImplementationOnce(async () => {
+				callOrder.push('changeLanguage');
+			});
+
+			await useAuthStore.getState().updateLocale('fr-FR');
+
+			expect(callOrder).toEqual(['updateLocale', 'changeLanguage']);
+			expect(mockUpdateLocale).toHaveBeenCalledWith('fr-FR');
+			expect(useAuthStore.getState().userInfo).toEqual({
+				...mockUser,
+				locale: 'fr-FR',
+			});
+			expect(useAuthStore.getState().isLocaleUpdating).toBe(false);
+		});
+
+		it('exposes pending state until locale synchronization completes', async () => {
+			let resolveUpdate: ((response: { locale: 'it-IT' }) => void) | undefined;
+			useAuthStore.setState({ userInfo: mockUser });
+			mockUpdateLocale.mockReturnValueOnce(
+				new Promise((resolve) => {
+					resolveUpdate = resolve;
+				})
+			);
+
+			const updatePromise = useAuthStore.getState().updateLocale('it-IT');
+
+			expect(useAuthStore.getState().isLocaleUpdating).toBe(true);
+
+			resolveUpdate?.({ locale: 'it-IT' });
+			await updatePromise;
+
+			expect(useAuthStore.getState().isLocaleUpdating).toBe(false);
+		});
+
+		it('leaves account and UI state unchanged when persistence fails', async () => {
+			useAuthStore.setState({ userInfo: mockUser });
+			mockUpdateLocale.mockRejectedValueOnce(new Error('network'));
+
+			await expect(
+				useAuthStore.getState().updateLocale('fr-FR')
+			).rejects.toThrow('network');
+
+			expect(mockChangeLanguage).not.toHaveBeenCalled();
+			expect(useAuthStore.getState().userInfo).toEqual(mockUser);
+			expect(useAuthStore.getState().isLocaleUpdating).toBe(false);
+		});
+
+		it('applies the requested locale when the update response is malformed', async () => {
+			useAuthStore.setState({ userInfo: mockUser });
+			mockUpdateLocale.mockResolvedValueOnce({ locale: 'de-DE' });
+
+			await useAuthStore.getState().updateLocale('fr-FR');
+
+			expect(mockChangeLanguage).toHaveBeenCalledWith('fr-FR');
+			expect(useAuthStore.getState().userInfo).toEqual({
+				...mockUser,
+				locale: 'fr-FR',
+			});
+			expect(useAuthStore.getState().isLocaleUpdating).toBe(false);
+			expect(consoleErrorSpy).toHaveBeenCalled();
+		});
+
+		it('does not persist the already-active account locale', async () => {
+			useAuthStore.setState({ userInfo: mockUser });
+
+			await useAuthStore.getState().updateLocale('en-US');
+
+			expect(mockUpdateLocale).not.toHaveBeenCalled();
+			expect(mockChangeLanguage).not.toHaveBeenCalled();
 		});
 	});
 

--- a/src/features/movie-search/pages/MovieSearchPage.tsx
+++ b/src/features/movie-search/pages/MovieSearchPage.tsx
@@ -5,7 +5,8 @@ import { MovieSearchList } from '../components';
 import { useMoviesStore } from '../stores';
 
 const MoviesPage = () => {
-	const { t } = useTranslation();
+	const { t, i18n } = useTranslation();
+	const activeLocale = i18n.resolvedLanguage ?? i18n.language;
 	const [query, setQuery] = useState('');
 	const loadMovieSearchResults = useMoviesStore(
 		(state) => state.loadMovieSearchResults
@@ -15,7 +16,13 @@ const MoviesPage = () => {
 	);
 
 	useEffect(() => {
-		if (!query || query.length < 3) {
+		if (activeLocale) {
+			resetMovieSearchResults();
+		}
+	}, [activeLocale, resetMovieSearchResults]);
+
+	useEffect(() => {
+		if (!activeLocale || !query || query.length < 3) {
 			resetMovieSearchResults();
 			return;
 		}
@@ -25,7 +32,7 @@ const MoviesPage = () => {
 		}, 500);
 
 		return () => clearTimeout(timer);
-	}, [query]);
+	}, [query, activeLocale, loadMovieSearchResults, resetMovieSearchResults]);
 
 	return (
 		<>

--- a/src/features/movie-search/pages/MovieSearchPage.unit.test.tsx
+++ b/src/features/movie-search/pages/MovieSearchPage.unit.test.tsx
@@ -1,9 +1,12 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+let activeLocale = 'en-US';
+
 vi.mock('react-i18next', () => ({
 	useTranslation: () => ({
 		t: (key: string) => key,
+		i18n: { resolvedLanguage: activeLocale },
 	}),
 }));
 
@@ -27,6 +30,7 @@ describe('MovieSearchPage', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		vi.useFakeTimers();
+		activeLocale = 'en-US';
 	});
 
 	afterEach(() => {
@@ -121,5 +125,44 @@ describe('MovieSearchPage', () => {
 		// Should only have searched for the final value
 		expect(mockLoadMovieSearchResults).toHaveBeenCalledTimes(1);
 		expect(mockLoadMovieSearchResults).toHaveBeenCalledWith('Inception');
+	});
+
+	it('refetches the active query when the locale changes', () => {
+		const { rerender } = render(<MovieSearchPage />);
+		const input = screen.getByPlaceholderText(
+			'MovieSearchPage.searchPlaceholder'
+		);
+		fireEvent.change(input, { target: { value: 'Inception' } });
+		act(() => {
+			vi.advanceTimersByTime(500);
+		});
+		mockLoadMovieSearchResults.mockClear();
+
+		activeLocale = 'fr-FR';
+		rerender(<MovieSearchPage />);
+		act(() => {
+			vi.advanceTimersByTime(500);
+		});
+
+		expect(mockLoadMovieSearchResults).toHaveBeenCalledOnce();
+		expect(mockLoadMovieSearchResults).toHaveBeenCalledWith('Inception');
+	});
+
+	it('invalidates the current search immediately when the locale changes', () => {
+		const { rerender } = render(<MovieSearchPage />);
+		const input = screen.getByPlaceholderText(
+			'MovieSearchPage.searchPlaceholder'
+		);
+		fireEvent.change(input, { target: { value: 'Inception' } });
+		act(() => {
+			vi.advanceTimersByTime(500);
+		});
+		mockResetMovieSearchResults.mockClear();
+
+		activeLocale = 'fr-FR';
+		rerender(<MovieSearchPage />);
+
+		expect(mockResetMovieSearchResults).toHaveBeenCalledOnce();
+		expect(mockLoadMovieSearchResults).toHaveBeenCalledOnce();
 	});
 });

--- a/src/features/movie-search/stores/useMoviesStore.ts
+++ b/src/features/movie-search/stores/useMoviesStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { createLatestRequestGuard } from '@/lib/utilities/latest-request-guard';
 import type { TMDBMovieSearchResult } from '../models';
 import { search } from '../repositories/movies-repository';
 
@@ -12,23 +13,33 @@ interface MoviesStore {
 }
 
 export const useMoviesStore = create<MoviesStore>((set) => {
+	const searchGuard = createLatestRequestGuard();
+
 	return {
 		movieSearchResult: undefined,
 		isLoading: false,
 		searched: false,
 
 		loadMovieSearchResults: async (query: string) => {
-			set({ isLoading: true });
+			const requestId = searchGuard.start();
+			set({ isLoading: true, movieSearchResult: undefined });
 			try {
 				const results = await search(query);
+				if (searchGuard.isStale(requestId)) return;
 				set({ movieSearchResult: results, isLoading: false, searched: true });
 			} catch (error) {
+				if (searchGuard.isStale(requestId)) return;
 				console.error('Error loading movie search results:', error);
 				set({ isLoading: false });
 			}
 		},
 		resetMovieSearchResults: () => {
-			set({ movieSearchResult: undefined });
+			searchGuard.invalidate();
+			set({
+				movieSearchResult: undefined,
+				isLoading: false,
+				searched: false,
+			});
 		},
 	};
 });

--- a/src/features/movie-search/stores/useMoviesStore.unit.test.ts
+++ b/src/features/movie-search/stores/useMoviesStore.unit.test.ts
@@ -78,6 +78,38 @@ describe('useMoviesStore', () => {
 			);
 			consoleSpy.mockRestore();
 		});
+
+		it('ignores an older response that finishes after a newer search', async () => {
+			let resolveFirst: (value: unknown) => void;
+			let resolveSecond: (value: unknown) => void;
+			mockSearch
+				.mockReturnValueOnce(
+					new Promise((resolve) => {
+						resolveFirst = resolve;
+					})
+				)
+				.mockReturnValueOnce(
+					new Promise((resolve) => {
+						resolveSecond = resolve;
+					})
+				);
+
+			const firstRequest = useMoviesStore
+				.getState()
+				.loadMovieSearchResults('old');
+			const secondRequest = useMoviesStore
+				.getState()
+				.loadMovieSearchResults('new');
+
+			resolveSecond!({ results: [{ id: 2, title: 'New locale' }] });
+			await secondRequest;
+			resolveFirst!({ results: [{ id: 1, title: 'Old locale' }] });
+			await firstRequest;
+
+			expect(useMoviesStore.getState().movieSearchResult).toEqual({
+				results: [{ id: 2, title: 'New locale' }],
+			});
+		});
 	});
 
 	describe('resetMovieSearchResults', () => {

--- a/src/features/movie/components/MovieLogItem.integration.test.tsx
+++ b/src/features/movie/components/MovieLogItem.integration.test.tsx
@@ -20,6 +20,11 @@ vi.mock('react-i18next', () => ({
 	}),
 }));
 
+vi.mock('@/lib/locales/i18n', () => ({
+	changeActiveLocale: vi.fn(),
+	getActiveLocale: () => 'en-US',
+}));
+
 describe('MovieLogItem Integration Tests', () => {
 	describe('T4.1.1: Navigation Integration with React Router', () => {
 		it('should render component with BrowserRouter without errors', () => {

--- a/src/features/movie/pages/MovieDetailsPage.tsx
+++ b/src/features/movie/pages/MovieDetailsPage.tsx
@@ -14,7 +14,8 @@ import { useMovieDetailsStore } from '../stores/useMovieDetailsStore';
 import { useMovieRatingStore } from '../stores/useMovieRatingStore';
 
 const MovieDetailsPage = () => {
-	const { t } = useTranslation();
+	const { t, i18n } = useTranslation();
+	const activeLocale = i18n.resolvedLanguage ?? i18n.language;
 	const { tmdbId } = useParams<{ tmdbId: string }>();
 	const navigate = useNavigate();
 	const movieDetails = useMovieDetailsStore((state) => state.movieDetails);
@@ -37,14 +38,22 @@ const MovieDetailsPage = () => {
 	const openLogDialog = useMovieLogDialogStore((state) => state.open);
 
 	useEffect(() => {
-		if (tmdbId) {
+		if (tmdbId && activeLocale) {
 			loadMovieDetails(Number(tmdbId));
+		}
+	}, [tmdbId, activeLocale, loadMovieDetails]);
+
+	useEffect(() => {
+		if (tmdbId) {
 			loadMovieRating(Number(tmdbId));
 		}
+	}, [tmdbId, loadMovieRating]);
+
+	useEffect(() => {
 		return () => {
 			resetMovieDetails();
 		};
-	}, [tmdbId, loadMovieDetails, loadMovieRating, resetMovieDetails]);
+	}, [resetMovieDetails]);
 
 	const onRateMovieUpdated = (movieRating: MovieRatingResponse) => {
 		if (tmdbId) {

--- a/src/features/movie/pages/MovieDetailsPage.unit.test.tsx
+++ b/src/features/movie/pages/MovieDetailsPage.unit.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockNavigate = vi.fn();
 const mockUseParams = vi.fn();
+let activeLocale = 'en-US';
 
 const movieDetailsState = {
 	movieDetails: undefined as
@@ -43,6 +44,7 @@ vi.mock('react-router-dom', () => ({
 vi.mock('react-i18next', () => ({
 	useTranslation: () => ({
 		t: (key: string) => key,
+		i18n: { resolvedLanguage: activeLocale },
 	}),
 }));
 
@@ -129,6 +131,7 @@ import MovieDetailsPage from './MovieDetailsPage';
 describe('MovieDetailsPage', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		activeLocale = 'en-US';
 		mockUseParams.mockReturnValue({ tmdbId: '10' });
 		movieDetailsState.movieDetails = undefined;
 		movieDetailsState.movieRating = undefined;
@@ -253,5 +256,16 @@ describe('MovieDetailsPage', () => {
 		render(<MovieDetailsPage />);
 
 		expect(screen.getByTestId('movie-vote-user')).toHaveTextContent('0');
+	});
+
+	it('refetches localized details without refetching the user rating', () => {
+		const { rerender } = render(<MovieDetailsPage />);
+		vi.clearAllMocks();
+
+		activeLocale = 'it-IT';
+		rerender(<MovieDetailsPage />);
+
+		expect(movieDetailsState.loadMovieDetails).toHaveBeenCalledWith(10);
+		expect(movieDetailsState.loadMovieRating).not.toHaveBeenCalled();
 	});
 });

--- a/src/features/movie/stores/useMovieDetailsStore.ts
+++ b/src/features/movie/stores/useMovieDetailsStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { createLatestRequestGuard } from '@/lib/utilities/latest-request-guard';
 import type { MovieRatingResponse } from '../models';
 import type { TMDBMovieDetails } from '../models/tmdb-movie-details';
 import { getMovieRating } from '../repositories/movie-rating-repository';
@@ -16,17 +17,22 @@ interface MovieDetailsStore {
 }
 
 export const useMovieDetailsStore = create<MovieDetailsStore>((set) => {
+	const detailsGuard = createLatestRequestGuard();
+
 	return {
 		movieDetails: undefined,
 		movieRating: undefined,
 		isLoading: false,
 		isMovieRatingLoading: false,
 		loadMovieDetails: async (tmdbId: number) => {
+			const requestId = detailsGuard.start();
 			set({ isLoading: true, movieDetails: undefined });
 			try {
 				const details = await getDetails(tmdbId);
+				if (detailsGuard.isStale(requestId)) return;
 				set({ movieDetails: details, isLoading: false });
 			} catch (error) {
+				if (detailsGuard.isStale(requestId)) return;
 				console.error('Error loading movie details:', error);
 				set({ isLoading: false });
 			}
@@ -35,6 +41,7 @@ export const useMovieDetailsStore = create<MovieDetailsStore>((set) => {
 			set({ movieRating });
 		},
 		resetMovieDetails: () => {
+			detailsGuard.invalidate();
 			set({ movieDetails: undefined, movieRating: undefined });
 		},
 		loadMovieRating: async (tmdbId: number) => {

--- a/src/features/movie/stores/useMovieDetailsStore.unit.test.ts
+++ b/src/features/movie/stores/useMovieDetailsStore.unit.test.ts
@@ -53,6 +53,35 @@ describe('useMovieDetailsStore', () => {
 		consoleSpy.mockRestore();
 	});
 
+	it('ignores older localized details that resolve after a newer request', async () => {
+		let resolveFirst: (value: unknown) => void;
+		let resolveSecond: (value: unknown) => void;
+		mockGetDetails
+			.mockReturnValueOnce(
+				new Promise((resolve) => {
+					resolveFirst = resolve;
+				})
+			)
+			.mockReturnValueOnce(
+				new Promise((resolve) => {
+					resolveSecond = resolve;
+				})
+			);
+
+		const firstRequest = useMovieDetailsStore.getState().loadMovieDetails(1);
+		const secondRequest = useMovieDetailsStore.getState().loadMovieDetails(1);
+
+		resolveSecond!({ id: 1, title: 'Titolo nuovo' });
+		await secondRequest;
+		resolveFirst!({ id: 1, title: 'Old title' });
+		await firstRequest;
+
+		expect(useMovieDetailsStore.getState().movieDetails).toEqual({
+			id: 1,
+			title: 'Titolo nuovo',
+		});
+	});
+
 	it('sets and resets movie rating state', () => {
 		const movieRating = { rating: 8, comment: 'great' };
 		useMovieDetailsStore.getState().setMovieRating(movieRating as never);

--- a/src/features/profile/components/Profile.unit.test.tsx
+++ b/src/features/profile/components/Profile.unit.test.tsx
@@ -9,6 +9,11 @@ vi.mock('react-i18next', () => ({
 	}),
 }));
 
+vi.mock('@/lib/locales/i18n', () => ({
+	changeActiveLocale: vi.fn(),
+	getActiveLocale: () => 'en-US',
+}));
+
 vi.mock('@antoniobenincasa/ui', () => ({
 	Button: ({
 		children,

--- a/src/features/profile/components/ProfileHeader.unit.test.tsx
+++ b/src/features/profile/components/ProfileHeader.unit.test.tsx
@@ -7,6 +7,11 @@ vi.mock('react-i18next', () => ({
 	}),
 }));
 
+vi.mock('@/lib/locales/i18n', () => ({
+	changeActiveLocale: vi.fn(),
+	getActiveLocale: () => 'en-US',
+}));
+
 vi.mock('@antoniobenincasa/ui', () => ({
 	Button: ({
 		children,

--- a/src/features/profile/pages/ProfileMoviesWatchedPage.unit.test.tsx
+++ b/src/features/profile/pages/ProfileMoviesWatchedPage.unit.test.tsx
@@ -8,6 +8,11 @@ vi.mock('react-i18next', () => ({
 	}),
 }));
 
+vi.mock('@/lib/locales/i18n', () => ({
+	changeActiveLocale: vi.fn(),
+	getActiveLocale: () => 'en-US',
+}));
+
 vi.mock('@/features/movie/components/MoviesWatched', () => ({
 	MoviesWatched: ({ handle }: { handle: string }) => (
 		<div data-testid="movies-watched">{handle}</div>

--- a/src/lib/api/interceptors.ts
+++ b/src/lib/api/interceptors.ts
@@ -7,6 +7,7 @@ import ky, {
 import type { RefreshResponse } from '@/features/auth/models/auth-responses';
 import { refreshToken } from '@/features/auth/repositories/auth-repository';
 import { useAuthStore } from '@/features/auth/stores';
+import { getActiveLocale } from '@/lib/locales/i18n';
 import type { ApiClientOptions } from '@/lib/models/api-client-options';
 
 let refreshPromise: Promise<RefreshResponse> | null = null;
@@ -21,6 +22,8 @@ export const beforeRequestInterceptor = async (
 	request: KyRequest,
 	options: ApiClientOptions
 ) => {
+	request.headers.set('Accept-Language', getActiveLocale());
+
 	if (options.skipAuth) {
 		return;
 	}

--- a/src/lib/api/interceptors.unit.test.ts
+++ b/src/lib/api/interceptors.unit.test.ts
@@ -11,6 +11,10 @@ vi.mock('@/features/auth/repositories/auth-repository', () => ({
 	refreshToken: vi.fn(),
 }));
 
+vi.mock('@/lib/locales/i18n', () => ({
+	getActiveLocale: () => 'fr-FR',
+}));
+
 import { refreshToken } from '@/features/auth/repositories/auth-repository';
 import { useAuthStore } from '@/features/auth/stores';
 
@@ -86,6 +90,10 @@ describe('interceptors', () => {
 			await beforeRequestInterceptor(mockRequest, mockOptions);
 
 			expect(mockRequest.headers.set).toHaveBeenCalledWith(
+				'Accept-Language',
+				'fr-FR'
+			);
+			expect(mockRequest.headers.set).toHaveBeenCalledWith(
 				'X-CSRF-Token',
 				'test-csrf-token'
 			);
@@ -141,7 +149,14 @@ describe('interceptors', () => {
 
 			await beforeRequestInterceptor(mockRequest, mockOptions);
 
-			expect(mockRequest.headers.set).not.toHaveBeenCalled();
+			expect(mockRequest.headers.set).toHaveBeenCalledWith(
+				'Accept-Language',
+				'fr-FR'
+			);
+			expect(mockRequest.headers.set).not.toHaveBeenCalledWith(
+				'X-CSRF-Token',
+				expect.anything()
+			);
 		});
 
 		it('should handle lowercase method names', async () => {
@@ -166,7 +181,14 @@ describe('interceptors', () => {
 
 			await beforeRequestInterceptor(mockRequest, mockOptions);
 
-			expect(mockRequest.headers.set).not.toHaveBeenCalled();
+			expect(mockRequest.headers.set).toHaveBeenCalledWith(
+				'Accept-Language',
+				'fr-FR'
+			);
+			expect(mockRequest.headers.set).not.toHaveBeenCalledWith(
+				'X-CSRF-Token',
+				expect.anything()
+			);
 		});
 
 		it('should skip auth header logic when skipAuth is true', async () => {
@@ -177,7 +199,14 @@ describe('interceptors', () => {
 
 			await beforeRequestInterceptor(mockRequest, { skipAuth: true });
 
-			expect(mockRequest.headers.set).not.toHaveBeenCalled();
+			expect(mockRequest.headers.set).toHaveBeenCalledWith(
+				'Accept-Language',
+				'fr-FR'
+			);
+			expect(mockRequest.headers.set).not.toHaveBeenCalledWith(
+				'X-CSRF-Token',
+				expect.anything()
+			);
 		});
 	});
 

--- a/src/lib/components/ProfileDropdownMenu.tsx
+++ b/src/lib/components/ProfileDropdownMenu.tsx
@@ -3,32 +3,48 @@ import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
+	DropdownMenuRadioGroup,
+	DropdownMenuRadioItem,
 	DropdownMenuSeparator,
 	DropdownMenuSub,
 	DropdownMenuSubContent,
 	DropdownMenuSubTrigger,
 	DropdownMenuTrigger,
+	useNotification,
 } from '@antoniobenincasa/ui';
 import { Languages, LogOut, User } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '@/features/auth/stores';
+import type { Locale } from '@/lib/models';
 import { ThemeDropdown } from './ThemeDropdown';
 
 export const ProfileDropdownMenu = () => {
 	const navigate = useNavigate();
-	const { t, i18n } = useTranslation();
+	const { t } = useTranslation();
+	const { notify } = useNotification();
 
 	const logout = useAuthStore((state) => state.logout);
 	const userInfo = useAuthStore((state) => state.userInfo);
+	const updateLocale = useAuthStore((state) => state.updateLocale);
+	const isLocaleUpdating = useAuthStore((state) => state.isLocaleUpdating);
 
 	const handleLogout = async () => {
 		await logout();
 		navigate('/');
 	};
 
-	const changeLanguage = (lng: string) => {
-		i18n.changeLanguage(lng);
+	const changeLanguage = async (locale: Locale) => {
+		if (isLocaleUpdating || userInfo?.locale === locale) return;
+
+		try {
+			await updateLocale(locale);
+		} catch {
+			notify({
+				variant: 'danger',
+				message: t('ProfileDropdownMenu.localeUpdateError'),
+			});
+		}
 	};
 
 	const goToProfilePage = () => {
@@ -60,15 +76,29 @@ export const ProfileDropdownMenu = () => {
 						{t('ProfileDropdownMenu.language')}
 					</DropdownMenuSubTrigger>
 					<DropdownMenuSubContent>
-						<DropdownMenuItem onClick={() => changeLanguage('en')}>
-							{t('ProfileDropdownMenu.languages.en')}
-						</DropdownMenuItem>
-						<DropdownMenuItem onClick={() => changeLanguage('fr')}>
-							{t('ProfileDropdownMenu.languages.fr')}
-						</DropdownMenuItem>
-						<DropdownMenuItem onClick={() => changeLanguage('it')}>
-							{t('ProfileDropdownMenu.languages.it')}
-						</DropdownMenuItem>
+						<DropdownMenuRadioGroup value={userInfo?.locale}>
+							<DropdownMenuRadioItem
+								value="en-US"
+								disabled={isLocaleUpdating}
+								onClick={() => void changeLanguage('en-US')}
+							>
+								{t('ProfileDropdownMenu.languages.en')}
+							</DropdownMenuRadioItem>
+							<DropdownMenuRadioItem
+								value="fr-FR"
+								disabled={isLocaleUpdating}
+								onClick={() => void changeLanguage('fr-FR')}
+							>
+								{t('ProfileDropdownMenu.languages.fr')}
+							</DropdownMenuRadioItem>
+							<DropdownMenuRadioItem
+								value="it-IT"
+								disabled={isLocaleUpdating}
+								onClick={() => void changeLanguage('it-IT')}
+							>
+								{t('ProfileDropdownMenu.languages.it')}
+							</DropdownMenuRadioItem>
+						</DropdownMenuRadioGroup>
 					</DropdownMenuSubContent>
 				</DropdownMenuSub>
 				<ThemeDropdown context="submenu" />

--- a/src/lib/components/ProfileDropdownMenu.unit.test.tsx
+++ b/src/lib/components/ProfileDropdownMenu.unit.test.tsx
@@ -4,11 +4,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockNavigate = vi.fn();
 const mockLogout = vi.fn();
-const mockChangeLanguage = vi.fn();
+const mockUpdateLocale = vi.fn();
+const mockNotify = vi.fn();
 const mockSetTheme = vi.fn();
 
 const authState = {
-	userInfo: { handle: 'neo' } as { handle: string } | null,
+	userInfo: { handle: 'neo', locale: 'en-US' } as {
+		handle: string;
+		locale: 'en-US' | 'fr-FR' | 'it-IT';
+	} | null,
+	isLocaleUpdating: false,
 	theme: 'system' as 'dark' | 'light' | 'system',
 };
 
@@ -23,7 +28,6 @@ vi.mock('react-router-dom', async () => {
 vi.mock('react-i18next', () => ({
 	useTranslation: () => ({
 		t: (key: string) => key,
-		i18n: { changeLanguage: mockChangeLanguage },
 	}),
 }));
 
@@ -31,9 +35,20 @@ vi.mock('@/features/auth/stores', () => ({
 	useAuthStore: (
 		selector: (state: {
 			logout: () => Promise<void>;
-			userInfo: { handle: string } | null;
+			userInfo: {
+				handle: string;
+				locale: 'en-US' | 'fr-FR' | 'it-IT';
+			} | null;
+			isLocaleUpdating: boolean;
+			updateLocale: (locale: string) => Promise<void>;
 		}) => unknown
-	) => selector({ logout: mockLogout, userInfo: authState.userInfo }),
+	) =>
+		selector({
+			logout: mockLogout,
+			userInfo: authState.userInfo,
+			isLocaleUpdating: authState.isLocaleUpdating,
+			updateLocale: mockUpdateLocale,
+		}),
 }));
 
 vi.mock('@/lib/hooks/useTheme', () => ({
@@ -69,14 +84,21 @@ vi.mock('@antoniobenincasa/ui', () => ({
 	}) => <div data-value={value}>{children}</div>,
 	DropdownMenuRadioItem: ({
 		children,
+		disabled,
 		onClick,
 		value,
 	}: {
 		children?: ReactNode;
+		disabled?: boolean;
 		onClick?: () => void;
 		value?: string;
 	}) => (
-		<button type="button" data-value={value} onClick={onClick}>
+		<button
+			type="button"
+			data-value={value}
+			disabled={disabled}
+			onClick={onClick}
+		>
 			{children}
 		</button>
 	),
@@ -92,6 +114,7 @@ vi.mock('@antoniobenincasa/ui', () => ({
 			{children}
 		</button>
 	),
+	useNotification: () => ({ notify: mockNotify }),
 }));
 
 vi.mock('lucide-react', () => ({
@@ -106,9 +129,11 @@ import { ProfileDropdownMenu } from './ProfileDropdownMenu';
 describe('ProfileDropdownMenu', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		authState.userInfo = { handle: 'neo' };
+		authState.userInfo = { handle: 'neo', locale: 'en-US' };
+		authState.isLocaleUpdating = false;
 		authState.theme = 'system';
 		mockLogout.mockResolvedValue(undefined);
+		mockUpdateLocale.mockResolvedValue(undefined);
 	});
 
 	it('navigates to profile when profile item is clicked', () => {
@@ -124,15 +149,58 @@ describe('ProfileDropdownMenu', () => {
 		expect(mockNavigate).not.toHaveBeenCalledWith('/profile/neo');
 	});
 
-	it('changes language from language menu items', () => {
+	it('persists full locale tags from language menu items', () => {
 		render(<ProfileDropdownMenu />);
-		fireEvent.click(screen.getByText('ProfileDropdownMenu.languages.en'));
 		fireEvent.click(screen.getByText('ProfileDropdownMenu.languages.fr'));
 		fireEvent.click(screen.getByText('ProfileDropdownMenu.languages.it'));
 
-		expect(mockChangeLanguage).toHaveBeenCalledWith('en');
-		expect(mockChangeLanguage).toHaveBeenCalledWith('fr');
-		expect(mockChangeLanguage).toHaveBeenCalledWith('it');
+		expect(mockUpdateLocale).toHaveBeenCalledWith('fr-FR');
+		expect(mockUpdateLocale).toHaveBeenCalledWith('it-IT');
+	});
+
+	it('marks the active locale and ignores its radio item', () => {
+		render(<ProfileDropdownMenu />);
+
+		expect(
+			screen.getByText('ProfileDropdownMenu.languages.en').parentElement
+		).toHaveAttribute('data-value', 'en-US');
+
+		fireEvent.click(screen.getByText('ProfileDropdownMenu.languages.en'));
+		expect(mockUpdateLocale).not.toHaveBeenCalled();
+	});
+
+	it('disables every locale while an update is pending', () => {
+		authState.isLocaleUpdating = true;
+
+		render(<ProfileDropdownMenu />);
+
+		expect(screen.getByText('ProfileDropdownMenu.languages.en')).toBeDisabled();
+		expect(screen.getByText('ProfileDropdownMenu.languages.fr')).toBeDisabled();
+		expect(screen.getByText('ProfileDropdownMenu.languages.it')).toBeDisabled();
+	});
+
+	it('shows only a danger notification when locale persistence fails', async () => {
+		mockUpdateLocale.mockRejectedValueOnce(new Error('network'));
+
+		render(<ProfileDropdownMenu />);
+		fireEvent.click(screen.getByText('ProfileDropdownMenu.languages.fr'));
+
+		await vi.waitFor(() =>
+			expect(mockNotify).toHaveBeenCalledWith({
+				variant: 'danger',
+				message: 'ProfileDropdownMenu.localeUpdateError',
+			})
+		);
+	});
+
+	it('does not show a success notification after persistence', async () => {
+		render(<ProfileDropdownMenu />);
+		fireEvent.click(screen.getByText('ProfileDropdownMenu.languages.fr'));
+
+		await vi.waitFor(() =>
+			expect(mockUpdateLocale).toHaveBeenCalledWith('fr-FR')
+		);
+		expect(mockNotify).not.toHaveBeenCalled();
 	});
 
 	it('changes theme from theme menu items', () => {

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -7,6 +7,7 @@
 	"ProfileDropdownMenu": {
 		"profile": "Profile",
 		"language": "Language",
+		"localeUpdateError": "Failed to update language preference",
 		"logout": "Logout",
 		"languages": {
 			"en": "English",

--- a/src/lib/locales/fr.json
+++ b/src/lib/locales/fr.json
@@ -7,6 +7,7 @@
 	"ProfileDropdownMenu": {
 		"profile": "Profil",
 		"language": "Langue",
+		"localeUpdateError": "Échec de la mise à jour de la langue",
 		"logout": "Déconnexion",
 		"languages": {
 			"en": "Anglais",

--- a/src/lib/locales/i18n.ts
+++ b/src/lib/locales/i18n.ts
@@ -1,20 +1,25 @@
 import i18n from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
-
+import {
+	DEFAULT_LOCALE,
+	LOCALE_VALUES,
+	type Locale,
+} from '@/lib/models/locale.model';
+import { normalizeLocale } from '@/lib/utilities/locale-utils';
 // Import translation files
 import en from './en.json';
 import fr from './fr.json';
 import it from './it.json';
 
 const resources = {
-	en: {
+	'en-US': {
 		translation: en,
 	},
-	fr: {
+	'fr-FR': {
 		translation: fr,
 	},
-	it: {
+	'it-IT': {
 		translation: it,
 	},
 };
@@ -24,8 +29,9 @@ i18n
 	.use(initReactI18next)
 	.init({
 		resources,
-		fallbackLng: 'en',
-		supportedLngs: ['en', 'fr', 'it'],
+		fallbackLng: DEFAULT_LOCALE,
+		supportedLngs: LOCALE_VALUES,
+		load: 'currentOnly',
 		interpolation: {
 			escapeValue: false,
 		},
@@ -35,7 +41,15 @@ i18n
 		detection: {
 			order: ['localStorage', 'navigator', 'htmlTag', 'path', 'subdomain'],
 			caches: ['localStorage'],
+			convertDetectedLanguage: (language) => normalizeLocale(language),
 		},
 	});
+
+export const getActiveLocale = (): Locale =>
+	normalizeLocale(i18n.resolvedLanguage ?? i18n.language);
+
+export const changeActiveLocale = async (locale: Locale): Promise<void> => {
+	await i18n.changeLanguage(locale);
+};
 
 export default i18n;

--- a/src/lib/locales/i18n.unit.test.ts
+++ b/src/lib/locales/i18n.unit.test.ts
@@ -1,15 +1,30 @@
 import { describe, expect, it } from 'vitest';
-import i18n from './i18n';
+import i18n, { changeActiveLocale, getActiveLocale } from './i18n';
 
 describe('i18n', () => {
 	it('initializes translations with expected languages and fallback', () => {
 		expect(i18n.isInitialized).toBe(true);
-		expect(i18n.options.fallbackLng).toEqual(['en']);
+		expect(i18n.options.fallbackLng).toEqual(['en-US']);
 		expect(i18n.options.supportedLngs).toEqual(
-			expect.arrayContaining(['en', 'fr', 'it'])
+			expect.arrayContaining(['en-US', 'fr-FR', 'it-IT'])
 		);
-		expect(i18n.hasResourceBundle('en', 'translation')).toBe(true);
-		expect(i18n.hasResourceBundle('fr', 'translation')).toBe(true);
-		expect(i18n.hasResourceBundle('it', 'translation')).toBe(true);
+		expect(i18n.hasResourceBundle('en-US', 'translation')).toBe(true);
+		expect(i18n.hasResourceBundle('fr-FR', 'translation')).toBe(true);
+		expect(i18n.hasResourceBundle('it-IT', 'translation')).toBe(true);
+	});
+
+	it('exposes the active language as a canonical full locale tag', async () => {
+		await i18n.changeLanguage('fr-FR');
+		expect(getActiveLocale()).toBe('fr-FR');
+		await i18n.changeLanguage('en-US');
+	});
+
+	it('changes the active language through the locale API', async () => {
+		await changeActiveLocale('it-IT');
+
+		expect(i18n.resolvedLanguage).toBe('it-IT');
+		expect(getActiveLocale()).toBe('it-IT');
+
+		await changeActiveLocale('en-US');
 	});
 });

--- a/src/lib/locales/it.json
+++ b/src/lib/locales/it.json
@@ -7,6 +7,7 @@
 	"ProfileDropdownMenu": {
 		"profile": "Profilo",
 		"language": "Lingua",
+		"localeUpdateError": "Impossibile aggiornare la lingua",
 		"logout": "Esci",
 		"languages": {
 			"en": "Inglese",

--- a/src/lib/models/index.ts
+++ b/src/lib/models/index.ts
@@ -1,3 +1,9 @@
+export type { Locale, TimeUnit } from './locale.model';
+export {
+	DEFAULT_LOCALE,
+	LOCALE_VALUES,
+	TIME_UNITS,
+} from './locale.model';
 export type { ProfileVisibility } from './profile-visibility';
 export { PROFILE_VISIBILITY_VALUES } from './profile-visibility';
 export type { Theme } from './theme';

--- a/src/lib/models/locale.model.ts
+++ b/src/lib/models/locale.model.ts
@@ -1,22 +1,8 @@
-export const locales = [
-	{
-		code: 'en',
-		name: 'English',
-		iso: 'en-US',
-	},
-	{
-		code: 'fr',
-		name: 'French',
-		iso: 'fr-FR',
-	},
-	{
-		code: 'it',
-		name: 'Italian',
-		iso: 'it-IT',
-	},
-];
+export const LOCALE_VALUES = ['en-US', 'fr-FR', 'it-IT'] as const;
 
-export type localeCodes = (typeof locales)[number]['code'];
+export type Locale = (typeof LOCALE_VALUES)[number];
+
+export const DEFAULT_LOCALE: Locale = 'en-US';
 
 export type TimeUnit = {
 	singular: string;
@@ -24,8 +10,8 @@ export type TimeUnit = {
 	short: string;
 };
 
-export const timeUnits: {
-	[localeCode: localeCodes]: {
+export const TIME_UNITS: {
+	[locale in Locale]: {
 		year: TimeUnit;
 		month: TimeUnit;
 		day: TimeUnit;
@@ -35,7 +21,7 @@ export const timeUnits: {
 		millisecond: TimeUnit;
 	};
 } = {
-	en: {
+	'en-US': {
 		year: {
 			singular: 'year',
 			plural: 'years',
@@ -72,7 +58,7 @@ export const timeUnits: {
 			short: 'ms',
 		},
 	},
-	fr: {
+	'fr-FR': {
 		year: {
 			singular: 'année',
 			plural: 'années',
@@ -109,7 +95,7 @@ export const timeUnits: {
 			short: 'ms',
 		},
 	},
-	it: {
+	'it-IT': {
 		year: {
 			singular: 'anno',
 			plural: 'anni',

--- a/src/lib/utilities/date-utils.ts
+++ b/src/lib/utilities/date-utils.ts
@@ -1,4 +1,5 @@
-import { timeUnits } from '../models/locale.model';
+import { TIME_UNITS } from '../models/locale.model';
+import { normalizeLocale } from './locale-utils';
 
 const MINS_PER_HOUR = 60;
 const MINS_PER_DAY = 1440;
@@ -12,15 +13,13 @@ function getTimeUnitsShort(locale: string): {
 	hour: string;
 	minute: string;
 } {
-	const validLocale = (
-		Object.hasOwn(timeUnits, locale) ? locale : 'en'
-	) as keyof typeof timeUnits;
+	const validLocale = normalizeLocale(locale);
 
-	const yearLocale = timeUnits[validLocale].year.short;
-	const monthLocale = timeUnits[validLocale].month.short;
-	const dayLocale = timeUnits[validLocale].day.short;
-	const hourLocale = timeUnits[validLocale].hour.short;
-	const minuteLocale = timeUnits[validLocale].minute.short;
+	const yearLocale = TIME_UNITS[validLocale].year.short;
+	const monthLocale = TIME_UNITS[validLocale].month.short;
+	const dayLocale = TIME_UNITS[validLocale].day.short;
+	const hourLocale = TIME_UNITS[validLocale].hour.short;
+	const minuteLocale = TIME_UNITS[validLocale].minute.short;
 
 	return {
 		year: yearLocale,

--- a/src/lib/utilities/date-utils.unit.test.ts
+++ b/src/lib/utilities/date-utils.unit.test.ts
@@ -171,6 +171,10 @@ describe('date-utils', () => {
 		});
 
 		describe('with Italian locale', () => {
+			it('supports the canonical Italian locale tag', () => {
+				expect(humanizeMinutes(90, 'it-IT')).toBe('1o 30min');
+			});
+
 			it('should return "0min" for 0 minutes', () => {
 				expect(humanizeMinutes(0, 'it')).toBe('0min');
 			});
@@ -189,6 +193,10 @@ describe('date-utils', () => {
 		});
 
 		describe('with French locale', () => {
+			it('supports the canonical French locale tag', () => {
+				expect(humanizeMinutes(90, 'fr-FR')).toBe('1h 30min');
+			});
+
 			it('should return "0min" for 0 minutes', () => {
 				expect(humanizeMinutes(0, 'fr')).toBe('0min');
 			});

--- a/src/lib/utilities/latest-request-guard.ts
+++ b/src/lib/utilities/latest-request-guard.ts
@@ -1,0 +1,17 @@
+export type LatestRequestGuard = {
+	start: () => number;
+	isStale: (requestId: number) => boolean;
+	invalidate: () => void;
+};
+
+export const createLatestRequestGuard = (): LatestRequestGuard => {
+	let latestRequestId = 0;
+
+	return {
+		start: () => ++latestRequestId,
+		isStale: (requestId: number) => requestId !== latestRequestId,
+		invalidate: () => {
+			latestRequestId++;
+		},
+	};
+};

--- a/src/lib/utilities/latest-request-guard.unit.test.ts
+++ b/src/lib/utilities/latest-request-guard.unit.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { createLatestRequestGuard } from './latest-request-guard';
+
+describe('createLatestRequestGuard', () => {
+	it('treats the most recently started request as not stale', () => {
+		const guard = createLatestRequestGuard();
+
+		const requestId = guard.start();
+
+		expect(guard.isStale(requestId)).toBe(false);
+	});
+
+	it('treats an earlier request as stale once a newer one starts', () => {
+		const guard = createLatestRequestGuard();
+
+		const firstRequestId = guard.start();
+		const secondRequestId = guard.start();
+
+		expect(guard.isStale(firstRequestId)).toBe(true);
+		expect(guard.isStale(secondRequestId)).toBe(false);
+	});
+
+	it('marks the current request as stale after invalidate', () => {
+		const guard = createLatestRequestGuard();
+
+		const requestId = guard.start();
+		guard.invalidate();
+
+		expect(guard.isStale(requestId)).toBe(true);
+	});
+});

--- a/src/lib/utilities/locale-utils.ts
+++ b/src/lib/utilities/locale-utils.ts
@@ -1,0 +1,31 @@
+import {
+	DEFAULT_LOCALE,
+	LOCALE_VALUES,
+	type Locale,
+} from '@/lib/models/locale.model';
+
+const LOCALES_BY_TAG = new Map(
+	LOCALE_VALUES.map((locale) => [locale.toLowerCase(), locale])
+);
+
+const LOCALES_BY_LANGUAGE = new Map(
+	LOCALE_VALUES.map((locale) => [locale.split('-', 1)[0].toLowerCase(), locale])
+);
+
+export const resolveSupportedLocale = (value: unknown): Locale | null => {
+	if (typeof value !== 'string') return null;
+
+	const normalized = value.trim().replaceAll('_', '-').toLowerCase();
+	if (!normalized) return null;
+
+	const exactLocale = LOCALES_BY_TAG.get(normalized);
+	if (exactLocale) return exactLocale;
+
+	const language = normalized.split('-', 1)[0];
+	return LOCALES_BY_LANGUAGE.get(language) ?? null;
+};
+
+export const normalizeLocale = (
+	value: unknown,
+	fallback: Locale = DEFAULT_LOCALE
+): Locale => resolveSupportedLocale(value) ?? fallback;

--- a/src/lib/utilities/locale-utils.unit.test.ts
+++ b/src/lib/utilities/locale-utils.unit.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_LOCALE, LOCALE_VALUES } from '@/lib/models';
+import { normalizeLocale, resolveSupportedLocale } from './locale-utils';
+
+describe('locale normalization', () => {
+	it('defines the backend-supported full locale tags', () => {
+		expect(LOCALE_VALUES).toEqual(['en-US', 'fr-FR', 'it-IT']);
+		expect(DEFAULT_LOCALE).toBe('en-US');
+	});
+
+	it.each([
+		['en-US', 'en-US'],
+		['fr-fr', 'fr-FR'],
+		['it_IT', 'it-IT'],
+		['en', 'en-US'],
+		['fr', 'fr-FR'],
+		['it', 'it-IT'],
+		['fr-CA', 'fr-FR'],
+		['en-GB', 'en-US'],
+	])('normalizes %s to %s', (input, expected) => {
+		expect(normalizeLocale(input)).toBe(expected);
+	});
+
+	it('uses the supplied fallback for missing and unsupported values', () => {
+		expect(normalizeLocale(undefined, 'it-IT')).toBe('it-IT');
+		expect(normalizeLocale('de-DE', 'fr-FR')).toBe('fr-FR');
+	});
+
+	it('returns null when a locale cannot be resolved', () => {
+		expect(resolveSupportedLocale('de-DE')).toBeNull();
+		expect(resolveSupportedLocale(null)).toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary
Closes #82. Frontend integration for benincasantonio/cinelog_server#213 — persists the active UI locale as an account preference and sends it to locale-aware backend requests.

- Registration requests now include the active locale (`en-US`, `fr-FR`, `it-IT`)
- `GET /v1/users/info` locale initializes i18n on session restore
- Language-menu changes persist through `PUT /v1/users/settings/locale`, with account/UI state kept consistent on failure (including a malformed-but-successful response)
- `Accept-Language` sent with the active full locale tag on all requests via the `ky` interceptor plus the two raw-`fetch` auth calls
- Signed-out sessions keep the existing localStorage/browser detection fallback
- Movie search and movie-details refetch when the active locale changes, guarded against out-of-order responses by a shared `createLatestRequestGuard` helper

See `docs/locale-preference-release.md` for the coordinated deployment plan and smoke checks.

Note: this branch also carries `ed86f3c` (`feat(profile): add follow controls and relationship counts`), pre-existing on this branch from an earlier rebase and unrelated to this feature.

## Test plan
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun run test:unit` (770 passing)
- [x] `bun run test:integration` (65 passing)
- [x] `bun run check:locales`
- [ ] Manual smoke checks per `docs/locale-preference-release.md` once the paired backend contract is deployed