### PR TITLE
feat(notifications): add in-app notification inbox page

### DIFF
--- a/src/features/notifications/components/NotificationItem.tsx
+++ b/src/features/notifications/components/NotificationItem.tsx
@@ -1,0 +1,51 @@
+import { useTranslation } from 'react-i18next';
+import { formatRelativeTime } from '@/lib/utilities/date-utils';
+import type { NotificationBaseResponse } from '../models';
+
+type NotificationItemProps = {
+	notification: NotificationBaseResponse;
+};
+
+export const NotificationItem = ({ notification }: NotificationItemProps) => {
+	const { i18n } = useTranslation();
+	const locale = i18n.resolvedLanguage ?? i18n.language;
+	const isUnread = notification.readAt === null;
+
+	return (
+		<article
+			data-testid="notification-item"
+			data-unread={isUnread}
+			className="flex items-start gap-3 rounded-xl border border-gray-200 p-4 dark:border-gray-800"
+		>
+			{isUnread ? (
+				<span
+					data-testid="unread-dot"
+					aria-hidden="true"
+					className="mt-2 size-2 shrink-0 rounded-full bg-primary"
+				/>
+			) : (
+				<span className="mt-2 size-2 shrink-0" aria-hidden="true" />
+			)}
+			<div className="flex min-w-0 flex-1 flex-col gap-1">
+				<h3
+					className={
+						isUnread
+							? 'font-semibold text-gray-900 dark:text-white'
+							: 'font-normal text-gray-700 dark:text-gray-300'
+					}
+				>
+					{notification.title}
+				</h3>
+				<p className="text-sm text-gray-600 dark:text-gray-400">
+					{notification.body}
+				</p>
+				<time
+					dateTime={notification.createdAt}
+					className="text-xs text-gray-500 dark:text-gray-500"
+				>
+					{formatRelativeTime(notification.createdAt, locale)}
+				</time>
+			</div>
+		</article>
+	);
+};

--- a/src/features/notifications/components/NotificationItem.unit.test.tsx
+++ b/src/features/notifications/components/NotificationItem.unit.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { NotificationBaseResponse } from '../models';
+import { NotificationItem } from './NotificationItem';
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({
+		t: (key: string) => key,
+		i18n: { language: 'en-US', resolvedLanguage: 'en-US' },
+	}),
+}));
+
+const unreadNotification: NotificationBaseResponse = {
+	id: 'n-1',
+	type: 'follow.started',
+	title: 'New follower',
+	body: 'A user started following you.',
+	actor: {
+		handle: 'moviefan',
+		firstName: 'Movie',
+		lastName: 'Fan',
+	},
+	availableActions: [],
+	readAt: null,
+	createdAt: '2026-07-18T10:30:00Z',
+};
+
+describe('NotificationItem', () => {
+	it('renders title, body, and timestamp without links or buttons', () => {
+		render(<NotificationItem notification={unreadNotification} />);
+
+		expect(screen.getByText('New follower')).toBeInTheDocument();
+		expect(
+			screen.getByText('A user started following you.')
+		).toBeInTheDocument();
+		expect(screen.queryByText('Movie Fan')).not.toBeInTheDocument();
+		expect(
+			document.querySelector('time[datetime="2026-07-18T10:30:00Z"]')
+		).toBeInTheDocument();
+		expect(screen.queryByRole('link')).not.toBeInTheDocument();
+		expect(screen.queryByRole('button')).not.toBeInTheDocument();
+	});
+
+	it('marks unread items with a dot and stronger title', () => {
+		render(<NotificationItem notification={unreadNotification} />);
+
+		expect(screen.getByTestId('unread-dot')).toBeInTheDocument();
+		expect(screen.getByText('New follower')).toHaveClass('font-semibold');
+	});
+
+	it('renders read items without a dot and with a quieter title', () => {
+		render(
+			<NotificationItem
+				notification={{
+					...unreadNotification,
+					readAt: '2026-07-18T11:00:00Z',
+				}}
+			/>
+		);
+
+		expect(screen.queryByTestId('unread-dot')).not.toBeInTheDocument();
+		expect(screen.getByText('New follower')).not.toHaveClass('font-semibold');
+	});
+});

--- a/src/features/notifications/components/NotificationList.tsx
+++ b/src/features/notifications/components/NotificationList.tsx
@@ -1,0 +1,78 @@
+import { Button, Spinner } from '@antoniobenincasa/ui';
+import { useTranslation } from 'react-i18next';
+import { useNotificationsStore } from '../stores';
+import { NotificationItem } from './NotificationItem';
+import { NotificationsEmptyState } from './NotificationsEmptyState';
+
+export const NotificationList = () => {
+	const { t } = useTranslation();
+	const items = useNotificationsStore((state) => state.items);
+	const nextCursor = useNotificationsStore((state) => state.nextCursor);
+	const unreadOnly = useNotificationsStore((state) => state.unreadOnly);
+	const isLoading = useNotificationsStore((state) => state.isLoading);
+	const isLoadingMore = useNotificationsStore((state) => state.isLoadingMore);
+	const error = useNotificationsStore((state) => state.error);
+	const hasLoaded = useNotificationsStore((state) => state.hasLoaded);
+	const loadNotifications = useNotificationsStore(
+		(state) => state.loadNotifications
+	);
+	const loadMore = useNotificationsStore((state) => state.loadMore);
+
+	if (isLoading && items.length === 0) {
+		return (
+			<div className="flex items-center justify-center gap-2 py-8">
+				<Spinner className="size-6 text-primary" />
+				<p className="text-lg text-gray-600 dark:text-gray-400">
+					{t('NotificationsPage.loading')}
+				</p>
+			</div>
+		);
+	}
+
+	if (error && items.length === 0) {
+		return (
+			<div className="flex flex-col items-center justify-center gap-3 py-8">
+				<p className="text-lg text-gray-600 dark:text-gray-400">
+					{t('NotificationsPage.error')}
+				</p>
+				<Button type="button" variant="outline" onClick={loadNotifications}>
+					{t('NotificationsPage.retry')}
+				</Button>
+			</div>
+		);
+	}
+
+	if (hasLoaded && items.length === 0) {
+		return <NotificationsEmptyState unreadOnly={unreadOnly} />;
+	}
+
+	return (
+		<div className="flex flex-col gap-3">
+			{items.map((notification) => (
+				<NotificationItem key={notification.id} notification={notification} />
+			))}
+
+			{error ? (
+				<div className="flex flex-col items-center gap-3 py-2">
+					<p className="text-sm text-gray-600 dark:text-gray-400">
+						{t('NotificationsPage.error')}
+					</p>
+					<Button type="button" variant="outline" onClick={loadMore}>
+						{t('NotificationsPage.retry')}
+					</Button>
+				</div>
+			) : null}
+
+			{nextCursor ? (
+				<Button
+					type="button"
+					variant="outline"
+					disabled={isLoadingMore}
+					onClick={loadMore}
+				>
+					{t('NotificationsPage.loadMore')}
+				</Button>
+			) : null}
+		</div>
+	);
+};

--- a/src/features/notifications/components/NotificationsEmptyState.tsx
+++ b/src/features/notifications/components/NotificationsEmptyState.tsx
@@ -1,0 +1,21 @@
+import { useTranslation } from 'react-i18next';
+
+type NotificationsEmptyStateProps = {
+	unreadOnly: boolean;
+};
+
+export const NotificationsEmptyState = ({
+	unreadOnly,
+}: NotificationsEmptyStateProps) => {
+	const { t } = useTranslation();
+
+	return (
+		<div className="flex justify-center py-8">
+			<p className="text-lg text-gray-600 dark:text-gray-400">
+				{unreadOnly
+					? t('NotificationsPage.emptyUnread')
+					: t('NotificationsPage.empty')}
+			</p>
+		</div>
+	);
+};

--- a/src/features/notifications/components/index.ts
+++ b/src/features/notifications/components/index.ts
@@ -1,0 +1,3 @@
+export { NotificationItem } from './NotificationItem';
+export { NotificationList } from './NotificationList';
+export { NotificationsEmptyState } from './NotificationsEmptyState';

--- a/src/features/notifications/models/index.ts
+++ b/src/features/notifications/models/index.ts
@@ -1,0 +1,10 @@
+export type {
+	NotificationActor,
+	NotificationBaseResponse,
+	NotificationListRequest,
+	NotificationListResponse,
+} from './notification';
+export type { NotificationAction } from './notification-action';
+export { NOTIFICATION_ACTION_VALUES } from './notification-action';
+export type { NotificationType } from './notification-type';
+export { NOTIFICATION_TYPE_VALUES } from './notification-type';

--- a/src/features/notifications/models/index.unit.test.ts
+++ b/src/features/notifications/models/index.unit.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import { NOTIFICATION_ACTION_VALUES, NOTIFICATION_TYPE_VALUES } from './index';
+
+describe('notification model barrel', () => {
+	it('re-exports the runtime enum arrays', () => {
+		expect(NOTIFICATION_TYPE_VALUES).toBeDefined();
+		expect(NOTIFICATION_ACTION_VALUES).toBeDefined();
+	});
+});

--- a/src/features/notifications/models/notification-action.ts
+++ b/src/features/notifications/models/notification-action.ts
@@ -1,0 +1,6 @@
+export const NOTIFICATION_ACTION_VALUES = [
+	'follow_request.accept',
+	'follow_request.reject',
+] as const;
+
+export type NotificationAction = (typeof NOTIFICATION_ACTION_VALUES)[number];

--- a/src/features/notifications/models/notification-action.unit.test.ts
+++ b/src/features/notifications/models/notification-action.unit.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import {
+	NOTIFICATION_ACTION_VALUES,
+	type NotificationAction,
+} from './notification-action';
+
+describe('notification action', () => {
+	it('exposes the supported wire values', () => {
+		expect(NOTIFICATION_ACTION_VALUES).toEqual([
+			'follow_request.accept',
+			'follow_request.reject',
+		]);
+	});
+
+	it('derives the notification action from the supported values', () => {
+		expectTypeOf<NotificationAction>().toEqualTypeOf<
+			'follow_request.accept' | 'follow_request.reject'
+		>();
+	});
+});

--- a/src/features/notifications/models/notification-type.ts
+++ b/src/features/notifications/models/notification-type.ts
@@ -1,0 +1,7 @@
+export const NOTIFICATION_TYPE_VALUES = [
+	'follow.started',
+	'follow.requested',
+	'follow.accepted',
+] as const;
+
+export type NotificationType = (typeof NOTIFICATION_TYPE_VALUES)[number];

--- a/src/features/notifications/models/notification-type.unit.test.ts
+++ b/src/features/notifications/models/notification-type.unit.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import {
+	NOTIFICATION_TYPE_VALUES,
+	type NotificationType,
+} from './notification-type';
+
+describe('notification type', () => {
+	it('exposes the supported wire values', () => {
+		expect(NOTIFICATION_TYPE_VALUES).toEqual([
+			'follow.started',
+			'follow.requested',
+			'follow.accepted',
+		]);
+	});
+
+	it('derives the notification type from the supported values', () => {
+		expectTypeOf<NotificationType>().toEqualTypeOf<
+			'follow.started' | 'follow.requested' | 'follow.accepted'
+		>();
+	});
+});

--- a/src/features/notifications/models/notification.ts
+++ b/src/features/notifications/models/notification.ts
@@ -1,0 +1,31 @@
+import type { NotificationAction } from './notification-action';
+import type { NotificationType } from './notification-type';
+
+export type NotificationActor = {
+	handle: string;
+	firstName: string;
+	lastName: string;
+};
+
+export type NotificationBaseResponse = {
+	id: string;
+	type: NotificationType;
+	title: string;
+	body: string;
+	actor: NotificationActor | null;
+	availableActions: NotificationAction[];
+	readAt: string | null;
+	createdAt: string;
+};
+
+export type NotificationListResponse = {
+	items: NotificationBaseResponse[];
+	nextCursor: string | null;
+	unreadCount: number;
+};
+
+export type NotificationListRequest = {
+	unreadOnly?: boolean;
+	limit?: number;
+	cursor?: string | null;
+};

--- a/src/features/notifications/pages/NotificationsPage.integration.test.tsx
+++ b/src/features/notifications/pages/NotificationsPage.integration.test.tsx
@@ -1,0 +1,127 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockListNotifications } = vi.hoisted(() => ({
+	mockListNotifications: vi.fn(),
+}));
+
+vi.mock('../repositories/notifications-repository', () => ({
+	listNotifications: (...args: unknown[]) => mockListNotifications(...args),
+}));
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({
+		t: (key: string) => key,
+		i18n: { language: 'en-US', resolvedLanguage: 'en-US' },
+	}),
+}));
+
+vi.mock('@antoniobenincasa/ui', () => ({
+	Button: ({
+		children,
+		onClick,
+		disabled,
+		...props
+	}: {
+		children?: ReactNode;
+		onClick?: () => void;
+		disabled?: boolean;
+	} & Record<string, unknown>) => (
+		<button type="button" onClick={onClick} disabled={disabled} {...props}>
+			{children}
+		</button>
+	),
+	Spinner: () => <div data-testid="spinner" />,
+}));
+
+import { useNotificationsStore } from '../stores';
+import NotificationsPage from './NotificationsPage';
+
+const firstItem = {
+	id: 'n-1',
+	type: 'follow.started' as const,
+	title: 'New follower',
+	body: 'A user started following you.',
+	actor: null,
+	availableActions: [] as const,
+	readAt: null,
+	createdAt: '2026-07-18T10:30:00Z',
+};
+
+const secondItem = {
+	id: 'n-2',
+	type: 'follow.accepted' as const,
+	title: 'Follow accepted',
+	body: 'Your follow request was accepted.',
+	actor: null,
+	availableActions: [] as const,
+	readAt: '2026-07-18T11:00:00Z',
+	createdAt: '2026-07-18T09:00:00Z',
+};
+
+const unreadItem = {
+	...firstItem,
+	id: 'n-unread',
+	title: 'Unread only item',
+};
+
+describe('NotificationsPage list flow', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		useNotificationsStore.setState({
+			items: [],
+			nextCursor: null,
+			unreadCount: 0,
+			unreadOnly: false,
+			isLoading: false,
+			isLoadingMore: false,
+			error: null,
+			hasLoaded: false,
+		});
+	});
+
+	it('lists notifications, filters unread, and loads more', async () => {
+		mockListNotifications
+			.mockResolvedValueOnce({
+				items: [firstItem],
+				nextCursor: 'cursor-1',
+				unreadCount: 2,
+			})
+			.mockResolvedValueOnce({
+				items: [unreadItem],
+				nextCursor: 'unread-cursor',
+				unreadCount: 1,
+			})
+			.mockResolvedValueOnce({
+				items: [secondItem],
+				nextCursor: null,
+				unreadCount: 1,
+			});
+
+		render(<NotificationsPage />);
+
+		expect(await screen.findByText('New follower')).toBeInTheDocument();
+		expect(mockListNotifications).toHaveBeenCalledWith({ unreadOnly: false });
+
+		fireEvent.click(screen.getByText('NotificationsPage.unreadOnly'));
+
+		expect(await screen.findByText('Unread only item')).toBeInTheDocument();
+		expect(screen.queryByText('New follower')).not.toBeInTheDocument();
+		expect(mockListNotifications).toHaveBeenCalledWith({ unreadOnly: true });
+
+		fireEvent.click(screen.getByText('NotificationsPage.loadMore'));
+
+		await waitFor(() => {
+			expect(screen.getByText('Follow accepted')).toBeInTheDocument();
+		});
+		expect(screen.getByText('Unread only item')).toBeInTheDocument();
+		expect(mockListNotifications).toHaveBeenCalledWith({
+			unreadOnly: true,
+			cursor: 'unread-cursor',
+		});
+		expect(
+			screen.queryByText('NotificationsPage.loadMore')
+		).not.toBeInTheDocument();
+	});
+});

--- a/src/features/notifications/pages/NotificationsPage.tsx
+++ b/src/features/notifications/pages/NotificationsPage.tsx
@@ -1,0 +1,45 @@
+import { Button } from '@antoniobenincasa/ui';
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { NotificationList } from '../components';
+import { useNotificationsStore } from '../stores';
+
+const NotificationsPage = () => {
+	const { t } = useTranslation();
+	const unreadOnly = useNotificationsStore((state) => state.unreadOnly);
+	const loadNotifications = useNotificationsStore(
+		(state) => state.loadNotifications
+	);
+	const setUnreadOnly = useNotificationsStore((state) => state.setUnreadOnly);
+	const reset = useNotificationsStore((state) => state.reset);
+
+	useEffect(() => {
+		loadNotifications();
+
+		return () => {
+			reset();
+		};
+	}, [loadNotifications, reset]);
+
+	return (
+		<>
+			<title>{t('NotificationsPage.pageTitle')}</title>
+			<div className="mx-auto flex w-full max-w-2xl flex-col gap-6">
+				<div className="flex items-center justify-between gap-4">
+					<h1 className="text-2xl font-bold">{t('NotificationsPage.title')}</h1>
+					<Button
+						type="button"
+						variant={unreadOnly ? 'default' : 'outline'}
+						aria-pressed={unreadOnly}
+						onClick={() => setUnreadOnly(!unreadOnly)}
+					>
+						{t('NotificationsPage.unreadOnly')}
+					</Button>
+				</div>
+				<NotificationList />
+			</div>
+		</>
+	);
+};
+
+export default NotificationsPage;

--- a/src/features/notifications/pages/NotificationsPage.unit.test.tsx
+++ b/src/features/notifications/pages/NotificationsPage.unit.test.tsx
@@ -1,0 +1,146 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NotificationBaseResponse } from '../models';
+
+const mockLoadNotifications = vi.fn();
+const mockLoadMore = vi.fn();
+const mockSetUnreadOnly = vi.fn();
+const mockReset = vi.fn();
+
+const storeState = {
+	items: [] as NotificationBaseResponse[],
+	nextCursor: null as string | null,
+	unreadOnly: false,
+	isLoading: false,
+	isLoadingMore: false,
+	error: null as string | null,
+	hasLoaded: false,
+	loadNotifications: mockLoadNotifications,
+	loadMore: mockLoadMore,
+	setUnreadOnly: mockSetUnreadOnly,
+	reset: mockReset,
+};
+
+vi.mock('../stores', () => ({
+	useNotificationsStore: (selector: (state: typeof storeState) => unknown) =>
+		selector(storeState),
+}));
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({
+		t: (key: string) => key,
+		i18n: { language: 'en-US', resolvedLanguage: 'en-US' },
+	}),
+}));
+
+vi.mock('@antoniobenincasa/ui', () => ({
+	Button: ({
+		children,
+		onClick,
+		disabled,
+		...props
+	}: {
+		children?: ReactNode;
+		onClick?: () => void;
+		disabled?: boolean;
+	} & Record<string, unknown>) => (
+		<button type="button" onClick={onClick} disabled={disabled} {...props}>
+			{children}
+		</button>
+	),
+	Spinner: () => <div data-testid="spinner" />,
+}));
+
+import NotificationsPage from './NotificationsPage';
+
+const sampleItem: NotificationBaseResponse = {
+	id: 'n-1',
+	type: 'follow.started',
+	title: 'New follower',
+	body: 'A user started following you.',
+	actor: null,
+	availableActions: [],
+	readAt: null,
+	createdAt: '2026-07-18T10:30:00Z',
+};
+
+describe('NotificationsPage', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		storeState.items = [];
+		storeState.nextCursor = null;
+		storeState.unreadOnly = false;
+		storeState.isLoading = false;
+		storeState.isLoadingMore = false;
+		storeState.error = null;
+		storeState.hasLoaded = false;
+	});
+
+	it('loads notifications on mount and resets on unmount', () => {
+		const { unmount } = render(<NotificationsPage />);
+
+		expect(mockLoadNotifications).toHaveBeenCalledOnce();
+		unmount();
+		expect(mockReset).toHaveBeenCalledOnce();
+	});
+
+	it('renders the loading state', () => {
+		storeState.isLoading = true;
+
+		render(<NotificationsPage />);
+
+		expect(screen.getByText('NotificationsPage.loading')).toBeInTheDocument();
+	});
+
+	it('renders the empty state', () => {
+		storeState.hasLoaded = true;
+
+		render(<NotificationsPage />);
+
+		expect(screen.getByText('NotificationsPage.empty')).toBeInTheDocument();
+	});
+
+	it('renders the unread empty state when the filter is on', () => {
+		storeState.hasLoaded = true;
+		storeState.unreadOnly = true;
+
+		render(<NotificationsPage />);
+
+		expect(
+			screen.getByText('NotificationsPage.emptyUnread')
+		).toBeInTheDocument();
+	});
+
+	it('renders a retryable error', () => {
+		storeState.hasLoaded = true;
+		storeState.error = 'Network error';
+
+		render(<NotificationsPage />);
+
+		expect(screen.getByText('NotificationsPage.error')).toBeInTheDocument();
+		fireEvent.click(screen.getByText('NotificationsPage.retry'));
+		expect(mockLoadNotifications).toHaveBeenCalledTimes(2);
+	});
+
+	it('renders items and load more', () => {
+		storeState.hasLoaded = true;
+		storeState.items = [sampleItem];
+		storeState.nextCursor = 'cursor-1';
+
+		render(<NotificationsPage />);
+
+		expect(screen.getByText('New follower')).toBeInTheDocument();
+		fireEvent.click(screen.getByText('NotificationsPage.loadMore'));
+		expect(mockLoadMore).toHaveBeenCalledOnce();
+	});
+
+	it('toggles the unread filter', () => {
+		storeState.hasLoaded = true;
+
+		render(<NotificationsPage />);
+
+		fireEvent.click(screen.getByText('NotificationsPage.unreadOnly'));
+		expect(mockSetUnreadOnly).toHaveBeenCalledWith(true);
+	});
+});

--- a/src/features/notifications/pages/index.ts
+++ b/src/features/notifications/pages/index.ts
@@ -1,0 +1,1 @@
+export { default } from './NotificationsPage';

--- a/src/features/notifications/repositories/index.ts
+++ b/src/features/notifications/repositories/index.ts
@@ -1,0 +1,4 @@
+export {
+	DEFAULT_NOTIFICATION_PAGE_SIZE,
+	listNotifications,
+} from './notifications-repository';

--- a/src/features/notifications/repositories/notifications-repository.ts
+++ b/src/features/notifications/repositories/notifications-repository.ts
@@ -1,0 +1,29 @@
+import { apiClient } from '@/lib/api/client';
+import type {
+	NotificationListRequest,
+	NotificationListResponse,
+} from '../models';
+import { parseNotificationListResponse } from '../schemas';
+
+export const DEFAULT_NOTIFICATION_PAGE_SIZE = 20;
+
+export const listNotifications = async (
+	params: NotificationListRequest = {}
+): Promise<NotificationListResponse> => {
+	const searchParams: {
+		unreadOnly: boolean;
+		limit: number;
+		cursor?: string;
+	} = {
+		unreadOnly: params.unreadOnly ?? false,
+		limit: params.limit ?? DEFAULT_NOTIFICATION_PAGE_SIZE,
+	};
+
+	if (params.cursor) {
+		searchParams.cursor = params.cursor;
+	}
+
+	const json = await apiClient.get('v1/notifications', { searchParams }).json();
+
+	return parseNotificationListResponse(json);
+};

--- a/src/features/notifications/repositories/notifications-repository.unit.test.ts
+++ b/src/features/notifications/repositories/notifications-repository.unit.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockGet, mockJson } = vi.hoisted(() => ({
+	mockGet: vi.fn(),
+	mockJson: vi.fn(),
+}));
+
+vi.mock('@/lib/api/client', () => ({
+	apiClient: {
+		get: mockGet,
+	},
+}));
+
+import { listNotifications } from './notifications-repository';
+
+const validItem = {
+	id: 'd51b78c5-1847-49dc-826f-461c87974c60',
+	type: 'follow.started',
+	title: 'New follower',
+	body: 'A user started following you.',
+	actor: {
+		handle: 'moviefan',
+		firstName: 'Movie',
+		lastName: 'Fan',
+	},
+	availableActions: [],
+	readAt: null,
+	createdAt: '2026-07-18T10:30:00Z',
+};
+
+const validList = {
+	items: [validItem],
+	nextCursor: 'cursor-1',
+	unreadCount: 1,
+};
+
+describe('listNotifications', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockJson.mockResolvedValue(validList);
+		mockGet.mockReturnValue({ json: mockJson });
+	});
+
+	it('requests the inbox with default unreadOnly and limit', async () => {
+		await expect(listNotifications()).resolves.toEqual(validList);
+
+		expect(mockGet).toHaveBeenCalledWith('v1/notifications', {
+			searchParams: {
+				unreadOnly: false,
+				limit: 20,
+			},
+		});
+		expect(mockJson).toHaveBeenCalledOnce();
+	});
+
+	it('forwards unreadOnly, limit, and cursor', async () => {
+		await listNotifications({
+			unreadOnly: true,
+			limit: 10,
+			cursor: 'cursor-1',
+		});
+
+		expect(mockGet).toHaveBeenCalledWith('v1/notifications', {
+			searchParams: {
+				unreadOnly: true,
+				limit: 10,
+				cursor: 'cursor-1',
+			},
+		});
+	});
+
+	it('omits cursor when it is null', async () => {
+		await listNotifications({ cursor: null });
+
+		expect(mockGet).toHaveBeenCalledWith('v1/notifications', {
+			searchParams: {
+				unreadOnly: false,
+				limit: 20,
+			},
+		});
+	});
+
+	it('parses the JSON body through the notification list schema', async () => {
+		mockJson.mockResolvedValueOnce({
+			items: [validItem, { ...validItem, id: 'bad', type: 'nope' }],
+			nextCursor: null,
+			unreadCount: 2,
+		});
+
+		await expect(listNotifications()).resolves.toEqual({
+			items: [validItem],
+			nextCursor: null,
+			unreadCount: 2,
+		});
+	});
+});

--- a/src/features/notifications/schemas/index.ts
+++ b/src/features/notifications/schemas/index.ts
@@ -1,0 +1,7 @@
+export {
+	type NotificationListSchema,
+	notificationActorSchema,
+	notificationItemSchema,
+	notificationListEnvelopeSchema,
+	parseNotificationListResponse,
+} from './notification-list.schema';

--- a/src/features/notifications/schemas/notification-list.schema.ts
+++ b/src/features/notifications/schemas/notification-list.schema.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod';
+import type { NotificationListResponse } from '../models';
+import {
+	NOTIFICATION_ACTION_VALUES,
+	NOTIFICATION_TYPE_VALUES,
+} from '../models';
+
+export const notificationActorSchema = z
+	.object({
+		handle: z.string(),
+		firstName: z.string(),
+		lastName: z.string(),
+	})
+	.strict();
+
+export const notificationItemSchema = z
+	.object({
+		id: z.string(),
+		type: z.enum(NOTIFICATION_TYPE_VALUES),
+		title: z.string(),
+		body: z.string(),
+		actor: notificationActorSchema.nullable(),
+		availableActions: z.array(z.enum(NOTIFICATION_ACTION_VALUES)),
+		readAt: z.string().nullable(),
+		createdAt: z.string(),
+	})
+	.strict();
+
+export const notificationListEnvelopeSchema = z
+	.object({
+		items: z.array(z.unknown()),
+		nextCursor: z.string().nullable(),
+		unreadCount: z.number(),
+	})
+	.strict();
+
+export type NotificationListSchema = z.infer<
+	typeof notificationListEnvelopeSchema
+> & {
+	items: z.infer<typeof notificationItemSchema>[];
+};
+
+export const parseNotificationListResponse = (
+	data: unknown
+): NotificationListResponse => {
+	const envelope = notificationListEnvelopeSchema.parse(data);
+	const items = envelope.items.flatMap((item) => {
+		const result = notificationItemSchema.safeParse(item);
+		return result.success ? [result.data] : [];
+	});
+
+	return {
+		items,
+		nextCursor: envelope.nextCursor,
+		unreadCount: envelope.unreadCount,
+	};
+};

--- a/src/features/notifications/schemas/notification-list.schema.unit.test.ts
+++ b/src/features/notifications/schemas/notification-list.schema.unit.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import {
+	notificationItemSchema,
+	parseNotificationListResponse,
+} from './notification-list.schema';
+
+const validItem = {
+	id: 'd51b78c5-1847-49dc-826f-461c87974c60',
+	type: 'follow.started',
+	title: 'New follower',
+	body: 'A user started following you.',
+	actor: {
+		handle: 'moviefan',
+		firstName: 'Movie',
+		lastName: 'Fan',
+	},
+	availableActions: [],
+	readAt: null,
+	createdAt: '2026-07-18T10:30:00Z',
+};
+
+const validList = {
+	items: [validItem],
+	nextCursor: 'cursor-1',
+	unreadCount: 1,
+};
+
+describe('notificationItemSchema', () => {
+	it('accepts the documented camelCase item shape', () => {
+		const result = notificationItemSchema.safeParse(validItem);
+
+		expect(result.success).toBe(true);
+	});
+
+	it('accepts a null actor and a server read timestamp', () => {
+		const result = notificationItemSchema.safeParse({
+			...validItem,
+			actor: null,
+			readAt: '2026-07-18T11:00:00Z',
+			availableActions: ['follow_request.accept'],
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects an unknown notification type', () => {
+		const result = notificationItemSchema.safeParse({
+			...validItem,
+			type: 'movie.logged',
+		});
+
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects an unknown action value', () => {
+		const result = notificationItemSchema.safeParse({
+			...validItem,
+			availableActions: ['follow_request.snooze'],
+		});
+
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects extra fields', () => {
+		const result = notificationItemSchema.safeParse({
+			...validItem,
+			metadata: { movieId: '1' },
+		});
+
+		expect(result.success).toBe(false);
+	});
+});
+
+describe('parseNotificationListResponse', () => {
+	it('parses a valid list response', () => {
+		expect(parseNotificationListResponse(validList)).toEqual(validList);
+	});
+
+	it('drops invalid items without failing the rest of the inbox', () => {
+		const parsed = parseNotificationListResponse({
+			items: [
+				validItem,
+				{ ...validItem, id: 'bad-type', type: 'unknown.event' },
+				{
+					...validItem,
+					id: 'bad-action',
+					availableActions: ['not.a.real.action'],
+				},
+			],
+			nextCursor: null,
+			unreadCount: 3,
+		});
+
+		expect(parsed.items).toEqual([validItem]);
+		expect(parsed.nextCursor).toBeNull();
+		expect(parsed.unreadCount).toBe(3);
+	});
+
+	it('rejects extra fields on the list envelope', () => {
+		expect(() =>
+			parseNotificationListResponse({
+				...validList,
+				extra: true,
+			})
+		).toThrow();
+	});
+
+	it('rejects a missing nextCursor', () => {
+		expect(() =>
+			parseNotificationListResponse({
+				items: [],
+				unreadCount: 0,
+			})
+		).toThrow();
+	});
+});

--- a/src/features/notifications/stores/index.ts
+++ b/src/features/notifications/stores/index.ts
@@ -1,0 +1,1 @@
+export { useNotificationsStore } from './useNotificationsStore';

--- a/src/features/notifications/stores/useNotificationsStore.ts
+++ b/src/features/notifications/stores/useNotificationsStore.ts
@@ -1,0 +1,119 @@
+import { create } from 'zustand';
+import { createLatestRequestGuard } from '@/lib/utilities/latest-request-guard';
+import type { NotificationBaseResponse } from '../models';
+import { listNotifications } from '../repositories';
+
+interface NotificationsStore {
+	items: NotificationBaseResponse[];
+	nextCursor: string | null;
+	unreadCount: number;
+	unreadOnly: boolean;
+	isLoading: boolean;
+	isLoadingMore: boolean;
+	error: string | null;
+	hasLoaded: boolean;
+	loadNotifications: () => Promise<void>;
+	loadMore: () => Promise<void>;
+	setUnreadOnly: (unreadOnly: boolean) => Promise<void>;
+	reset: () => void;
+}
+
+const initialState = {
+	items: [] as NotificationBaseResponse[],
+	nextCursor: null as string | null,
+	unreadCount: 0,
+	unreadOnly: false,
+	isLoading: false,
+	isLoadingMore: false,
+	error: null as string | null,
+	hasLoaded: false,
+};
+
+export const useNotificationsStore = create<NotificationsStore>((set, get) => {
+	const requestGuard = createLatestRequestGuard();
+
+	return {
+		...initialState,
+
+		loadNotifications: async () => {
+			const requestId = requestGuard.start();
+			set({ isLoading: true, error: null });
+
+			try {
+				const result = await listNotifications({
+					unreadOnly: get().unreadOnly,
+				});
+
+				if (requestGuard.isStale(requestId)) return;
+
+				set({
+					items: result.items,
+					nextCursor: result.nextCursor,
+					unreadCount: result.unreadCount,
+					isLoading: false,
+					hasLoaded: true,
+				});
+			} catch (error) {
+				if (requestGuard.isStale(requestId)) return;
+
+				console.error('Error loading notifications:', error);
+				set({
+					isLoading: false,
+					error: (error as Error).message,
+					hasLoaded: true,
+				});
+			}
+		},
+
+		loadMore: async () => {
+			const { nextCursor, isLoading, isLoadingMore, unreadOnly } = get();
+			if (!nextCursor || isLoading || isLoadingMore) return;
+
+			const requestId = requestGuard.start();
+			set({ isLoadingMore: true, error: null });
+
+			try {
+				const result = await listNotifications({
+					unreadOnly,
+					cursor: nextCursor,
+				});
+
+				if (requestGuard.isStale(requestId)) return;
+
+				set((state) => ({
+					items: [...state.items, ...result.items],
+					nextCursor: result.nextCursor,
+					unreadCount: result.unreadCount,
+					isLoadingMore: false,
+				}));
+			} catch (error) {
+				if (requestGuard.isStale(requestId)) return;
+
+				console.error('Error loading more notifications:', error);
+				set({
+					isLoadingMore: false,
+					error: (error as Error).message,
+				});
+			}
+		},
+
+		setUnreadOnly: async (unreadOnly) => {
+			if (get().unreadOnly === unreadOnly) return;
+
+			set({
+				unreadOnly,
+				items: [],
+				nextCursor: null,
+				hasLoaded: false,
+				error: null,
+			});
+
+			await get().loadNotifications();
+		},
+
+		reset: () => {
+			requestGuard.invalidate();
+			set(initialState);
+		},
+	};
+});

--- a/src/features/notifications/stores/useNotificationsStore.unit.test.ts
+++ b/src/features/notifications/stores/useNotificationsStore.unit.test.ts
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockListNotifications } = vi.hoisted(() => ({
+	mockListNotifications: vi.fn(),
+}));
+
+vi.mock('../repositories/notifications-repository', () => ({
+	listNotifications: (...args: unknown[]) => mockListNotifications(...args),
+}));
+
+import { useNotificationsStore } from './useNotificationsStore';
+
+const firstPage = {
+	items: [
+		{
+			id: 'n-1',
+			type: 'follow.started',
+			title: 'New follower',
+			body: 'A user started following you.',
+			actor: null,
+			availableActions: [],
+			readAt: null,
+			createdAt: '2026-07-18T10:30:00Z',
+		},
+	],
+	nextCursor: 'cursor-1',
+	unreadCount: 2,
+};
+
+const secondPage = {
+	items: [
+		{
+			id: 'n-2',
+			type: 'follow.accepted',
+			title: 'Follow accepted',
+			body: 'Your follow request was accepted.',
+			actor: null,
+			availableActions: [],
+			readAt: '2026-07-18T11:00:00Z',
+			createdAt: '2026-07-18T09:00:00Z',
+		},
+	],
+	nextCursor: null,
+	unreadCount: 1,
+};
+
+const unreadPage = {
+	items: [firstPage.items[0]],
+	nextCursor: null,
+	unreadCount: 1,
+};
+
+const initialState = {
+	items: [],
+	nextCursor: null,
+	unreadCount: 0,
+	unreadOnly: false,
+	isLoading: false,
+	isLoadingMore: false,
+	error: null,
+	hasLoaded: false,
+};
+
+describe('useNotificationsStore', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		useNotificationsStore.setState(initialState);
+	});
+
+	it('has the expected initial values and no read-mutation actions', () => {
+		const state = useNotificationsStore.getState();
+
+		expect(state.items).toEqual([]);
+		expect(state.nextCursor).toBeNull();
+		expect(state.unreadCount).toBe(0);
+		expect(state.unreadOnly).toBe(false);
+		expect(state.isLoading).toBe(false);
+		expect(state.isLoadingMore).toBe(false);
+		expect(state.error).toBeNull();
+		expect(state.hasLoaded).toBe(false);
+		expect(state).not.toHaveProperty('markAsRead');
+		expect(state).not.toHaveProperty('markAllAsRead');
+	});
+
+	it('loads the first page and replaces items', async () => {
+		mockListNotifications.mockResolvedValueOnce(firstPage);
+
+		const pending = useNotificationsStore.getState().loadNotifications();
+		expect(useNotificationsStore.getState().isLoading).toBe(true);
+
+		await pending;
+
+		const state = useNotificationsStore.getState();
+		expect(mockListNotifications).toHaveBeenCalledWith({ unreadOnly: false });
+		expect(state.items).toEqual(firstPage.items);
+		expect(state.nextCursor).toBe('cursor-1');
+		expect(state.unreadCount).toBe(2);
+		expect(state.isLoading).toBe(false);
+		expect(state.hasLoaded).toBe(true);
+		expect(state.error).toBeNull();
+	});
+
+	it('sets error when the initial load fails', async () => {
+		const consoleSpy = vi
+			.spyOn(console, 'error')
+			.mockImplementation(() => undefined);
+		mockListNotifications.mockRejectedValueOnce(new Error('Network error'));
+
+		await useNotificationsStore.getState().loadNotifications();
+
+		expect(useNotificationsStore.getState().isLoading).toBe(false);
+		expect(useNotificationsStore.getState().error).toBe('Network error');
+		expect(useNotificationsStore.getState().hasLoaded).toBe(true);
+		expect(consoleSpy).toHaveBeenCalledWith(
+			'Error loading notifications:',
+			expect.any(Error)
+		);
+		consoleSpy.mockRestore();
+	});
+
+	it('appends the next page on loadMore', async () => {
+		useNotificationsStore.setState({
+			...firstPage,
+			unreadOnly: false,
+			hasLoaded: true,
+		});
+		mockListNotifications.mockResolvedValueOnce(secondPage);
+
+		await useNotificationsStore.getState().loadMore();
+
+		expect(mockListNotifications).toHaveBeenCalledWith({
+			unreadOnly: false,
+			cursor: 'cursor-1',
+		});
+		expect(
+			useNotificationsStore.getState().items.map((item) => item.id)
+		).toEqual(['n-1', 'n-2']);
+		expect(useNotificationsStore.getState().nextCursor).toBeNull();
+		expect(useNotificationsStore.getState().isLoadingMore).toBe(false);
+	});
+
+	it('does not request another page when nextCursor is null', async () => {
+		useNotificationsStore.setState({
+			items: firstPage.items,
+			nextCursor: null,
+			hasLoaded: true,
+		});
+
+		await useNotificationsStore.getState().loadMore();
+
+		expect(mockListNotifications).not.toHaveBeenCalled();
+	});
+
+	it('resets pagination and refetches when the unread filter changes', async () => {
+		useNotificationsStore.setState({
+			items: firstPage.items,
+			nextCursor: 'cursor-1',
+			unreadOnly: false,
+			hasLoaded: true,
+		});
+		mockListNotifications.mockResolvedValueOnce(unreadPage);
+
+		await useNotificationsStore.getState().setUnreadOnly(true);
+
+		expect(useNotificationsStore.getState().unreadOnly).toBe(true);
+		expect(mockListNotifications).toHaveBeenCalledWith({ unreadOnly: true });
+		expect(useNotificationsStore.getState().items).toEqual(unreadPage.items);
+		expect(useNotificationsStore.getState().nextCursor).toBeNull();
+	});
+
+	it('does not refetch when the unread filter is unchanged', async () => {
+		await useNotificationsStore.getState().setUnreadOnly(false);
+
+		expect(mockListNotifications).not.toHaveBeenCalled();
+	});
+
+	it('ignores an older first-page response after a newer filter fetch', async () => {
+		let resolveFirst: (value: unknown) => void;
+		let resolveSecond: (value: unknown) => void;
+		mockListNotifications
+			.mockReturnValueOnce(
+				new Promise((resolve) => {
+					resolveFirst = resolve;
+				})
+			)
+			.mockReturnValueOnce(
+				new Promise((resolve) => {
+					resolveSecond = resolve;
+				})
+			);
+
+		const firstRequest = useNotificationsStore.getState().loadNotifications();
+		const secondRequest = useNotificationsStore.getState().setUnreadOnly(true);
+
+		resolveSecond!(unreadPage);
+		await secondRequest;
+		resolveFirst!(firstPage);
+		await firstRequest;
+
+		expect(useNotificationsStore.getState().items).toEqual(unreadPage.items);
+		expect(useNotificationsStore.getState().unreadOnly).toBe(true);
+	});
+
+	it('resets store state', () => {
+		useNotificationsStore.setState({
+			items: firstPage.items,
+			nextCursor: 'cursor-1',
+			unreadCount: 2,
+			unreadOnly: true,
+			isLoading: true,
+			error: 'boom',
+			hasLoaded: true,
+		});
+
+		useNotificationsStore.getState().reset();
+
+		expect(useNotificationsStore.getState()).toMatchObject(initialState);
+	});
+});

--- a/src/lib/components/Navbar.tsx
+++ b/src/lib/components/Navbar.tsx
@@ -7,7 +7,7 @@ import {
 	NavigationMenuLink,
 	NavigationMenuList,
 } from '@antoniobenincasa/ui';
-import { Menu, User } from 'lucide-react';
+import { Bell, Menu, User } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate } from 'react-router-dom';
@@ -87,7 +87,19 @@ export const Navbar = () => {
 
 				{/* Right side - Auth buttons or User menu */}
 				<div className="flex items-center gap-4">
-					{authenticatedStatus === true && <CreateMovieLogButton />}
+					{authenticatedStatus === true && (
+						<>
+							<Button asChild variant="ghost" size="icon">
+								<Link
+									to="/notifications"
+									aria-label={t('Navbar.notifications')}
+								>
+									<Bell className="w-5 h-5" />
+								</Link>
+							</Button>
+							<CreateMovieLogButton />
+						</>
+					)}
 
 					{authenticatedStatus === false ? (
 						<>

--- a/src/lib/components/Navbar.unit.test.tsx
+++ b/src/lib/components/Navbar.unit.test.tsx
@@ -44,8 +44,9 @@ vi.mock('@antoniobenincasa/ui', () => ({
 	Button: ({
 		children,
 		onClick,
+		asChild: _asChild,
 		...props
-	}: { children?: ReactNode; onClick?: () => void } & Record<
+	}: { children?: ReactNode; onClick?: () => void; asChild?: boolean } & Record<
 		string,
 		unknown
 	>) => (
@@ -94,6 +95,7 @@ vi.mock('@antoniobenincasa/ui', () => ({
 }));
 
 vi.mock('lucide-react', () => ({
+	Bell: () => <span>bell</span>,
 	Menu: ({ onClick }: { onClick?: () => void }) => (
 		<button type="button" data-testid="menu-icon" onClick={onClick}>
 			menu
@@ -174,6 +176,9 @@ describe('Navbar', () => {
 			'Navbar.register'
 		);
 		expect(screen.queryByTestId('create-log-button')).not.toBeInTheDocument();
+		expect(
+			screen.queryByLabelText('Navbar.notifications')
+		).not.toBeInTheDocument();
 
 		fireEvent.click(screen.getByText('Navbar.login'));
 		fireEvent.click(screen.getByTestId('mobile-login-button'));
@@ -238,6 +243,14 @@ describe('Navbar', () => {
 		expect(screen.getByTestId('create-log-dialog')).toBeInTheDocument();
 		expect(screen.getByTestId('profile-dropdown')).toBeInTheDocument();
 		expect(screen.getByText('Navbar.search')).toBeInTheDocument();
+		const notificationsLink = screen.getByLabelText('Navbar.notifications');
+		expect(notificationsLink).toBeInTheDocument();
+		expect(notificationsLink).toHaveAttribute('href', '/notifications');
+		expect(notificationsLink).toHaveTextContent('bell');
+		expect(screen.queryByTestId('notifications-badge')).not.toBeInTheDocument();
+		expect(screen.getByTestId('mobile-navbar-items')).not.toHaveTextContent(
+			'Navbar.notifications'
+		);
 		expect(screen.getByTestId('mobile-navbar')).toHaveTextContent('closed');
 		expect(screen.getByTestId('mobile-navbar-items')).toHaveTextContent(
 			'Navbar.home,Navbar.search'

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -242,7 +242,8 @@
 		"search": "Search",
 		"theme": "Theme",
 		"login": "Login",
-		"register": "Register"
+		"register": "Register",
+		"notifications": "Notifications"
 	},
 	"HomePage": {
 		"pageTitle": "Cinelog - Home",
@@ -356,5 +357,16 @@
 			"followers_only": "Only followers you accept can view your full profile and movie logs.",
 			"private": "Only you can view your full profile and movie logs."
 		}
+	},
+	"NotificationsPage": {
+		"pageTitle": "Cinelog - Notifications",
+		"title": "Notifications",
+		"unreadOnly": "Unread only",
+		"loading": "Loading notifications...",
+		"empty": "No notifications yet",
+		"emptyUnread": "No unread notifications",
+		"error": "Failed to load notifications",
+		"retry": "Try again",
+		"loadMore": "Load more"
 	}
 }

--- a/src/lib/locales/fr.json
+++ b/src/lib/locales/fr.json
@@ -242,7 +242,8 @@
 		"search": "Rechercher",
 		"theme": "Thème",
 		"login": "Connexion",
-		"register": "S'inscrire"
+		"register": "S'inscrire",
+		"notifications": "Notifications"
 	},
 	"HomePage": {
 		"pageTitle": "Cinelog - Accueil",
@@ -356,5 +357,16 @@
 			"followers_only": "Seuls les abonnés que vous acceptez peuvent voir votre profil complet et les films que vous avez enregistrés.",
 			"private": "Vous seul pouvez voir votre profil complet et les films que vous avez enregistrés."
 		}
+	},
+	"NotificationsPage": {
+		"pageTitle": "Cinelog - Notifications",
+		"title": "Notifications",
+		"unreadOnly": "Non lues uniquement",
+		"loading": "Chargement des notifications...",
+		"empty": "Aucune notification",
+		"emptyUnread": "Aucune notification non lue",
+		"error": "Impossible de charger les notifications",
+		"retry": "Réessayer",
+		"loadMore": "Charger plus"
 	}
 }

--- a/src/lib/locales/it.json
+++ b/src/lib/locales/it.json
@@ -242,7 +242,8 @@
 		"search": "Cerca",
 		"theme": "Tema",
 		"login": "Accedi",
-		"register": "Registrati"
+		"register": "Registrati",
+		"notifications": "Notifiche"
 	},
 	"HomePage": {
 		"pageTitle": "Cinelog - Home",
@@ -356,5 +357,16 @@
 			"followers_only": "Solo i follower che accetti possono vedere il tuo profilo completo e i film che hai registrato.",
 			"private": "Solo tu puoi vedere il tuo profilo completo e i film che hai registrato."
 		}
+	},
+	"NotificationsPage": {
+		"pageTitle": "Cinelog - Notifiche",
+		"title": "Notifiche",
+		"unreadOnly": "Solo non lette",
+		"loading": "Caricamento delle notifiche...",
+		"empty": "Nessuna notifica",
+		"emptyUnread": "Nessuna notifica non letta",
+		"error": "Impossibile caricare le notifiche",
+		"retry": "Riprova",
+		"loadMore": "Carica altri"
 	}
 }

--- a/src/lib/utilities/date-utils.ts
+++ b/src/lib/utilities/date-utils.ts
@@ -117,3 +117,56 @@ export const humanizeMinutes = (minutes: number, locale: string): string => {
 
 	return humanizedValue.trim();
 };
+
+const RELATIVE_TIME_IN_SECONDS = {
+	minute: 60,
+	hour: 60 * 60,
+	day: 60 * 60 * 24,
+	month: 60 * 60 * 24 * 30,
+	year: 60 * 60 * 24 * 365,
+} as const;
+
+export const formatRelativeTime = (
+	iso: string,
+	locale: string,
+	now: number = Date.now()
+): string => {
+	const then = new Date(iso).getTime();
+	if (Number.isNaN(then)) return iso;
+
+	const diffSeconds = Math.round((then - now) / 1000);
+	const abs = Math.abs(diffSeconds);
+	const formatter = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' });
+
+	if (abs < RELATIVE_TIME_IN_SECONDS.minute) {
+		return formatter.format(diffSeconds, 'second');
+	}
+	if (abs < RELATIVE_TIME_IN_SECONDS.hour) {
+		return formatter.format(
+			Math.round(diffSeconds / RELATIVE_TIME_IN_SECONDS.minute),
+			'minute'
+		);
+	}
+	if (abs < RELATIVE_TIME_IN_SECONDS.day) {
+		return formatter.format(
+			Math.round(diffSeconds / RELATIVE_TIME_IN_SECONDS.hour),
+			'hour'
+		);
+	}
+	if (abs < RELATIVE_TIME_IN_SECONDS.month) {
+		return formatter.format(
+			Math.round(diffSeconds / RELATIVE_TIME_IN_SECONDS.day),
+			'day'
+		);
+	}
+	if (abs < RELATIVE_TIME_IN_SECONDS.year) {
+		return formatter.format(
+			Math.round(diffSeconds / RELATIVE_TIME_IN_SECONDS.month),
+			'month'
+		);
+	}
+	return formatter.format(
+		Math.round(diffSeconds / RELATIVE_TIME_IN_SECONDS.year),
+		'year'
+	);
+};

--- a/src/lib/utilities/date-utils.unit.test.ts
+++ b/src/lib/utilities/date-utils.unit.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { convertMinutesToTime, humanizeMinutes } from './date-utils';
+import {
+	convertMinutesToTime,
+	formatRelativeTime,
+	humanizeMinutes,
+} from './date-utils';
 
 describe('date-utils', () => {
 	describe('convertMinutesToTime', () => {
@@ -222,6 +226,65 @@ describe('date-utils', () => {
 			it('should fall back to English for undefined locale', () => {
 				expect(humanizeMinutes(60, 'de')).toBe('1h');
 			});
+		});
+	});
+
+	describe('formatRelativeTime', () => {
+		const now = Date.parse('2026-07-18T10:30:00Z');
+		const relative = (
+			locale: string,
+			value: number,
+			unit: Intl.RelativeTimeFormatUnit
+		) =>
+			new Intl.RelativeTimeFormat(locale, { numeric: 'auto' }).format(
+				value,
+				unit
+			);
+
+		it('returns the original value when the timestamp is invalid', () => {
+			expect(formatRelativeTime('not-a-date', 'en-US', now)).toBe('not-a-date');
+		});
+
+		it('formats a difference under a minute in seconds', () => {
+			expect(formatRelativeTime('2026-07-18T10:29:30Z', 'en-US', now)).toBe(
+				relative('en-US', -30, 'second')
+			);
+		});
+
+		it('formats a difference under an hour in minutes', () => {
+			expect(formatRelativeTime('2026-07-18T10:28:00Z', 'en-US', now)).toBe(
+				relative('en-US', -2, 'minute')
+			);
+		});
+
+		it('formats a difference under a day in hours', () => {
+			expect(formatRelativeTime('2026-07-18T07:30:00Z', 'en-US', now)).toBe(
+				relative('en-US', -3, 'hour')
+			);
+		});
+
+		it('formats a difference under a month in days', () => {
+			expect(formatRelativeTime('2026-07-16T10:30:00Z', 'en-US', now)).toBe(
+				relative('en-US', -2, 'day')
+			);
+		});
+
+		it('formats a difference under a year in months', () => {
+			expect(formatRelativeTime('2026-05-18T10:30:00Z', 'en-US', now)).toBe(
+				relative('en-US', -2, 'month')
+			);
+		});
+
+		it('formats a difference of a year or more in years', () => {
+			expect(formatRelativeTime('2024-07-18T10:30:00Z', 'en-US', now)).toBe(
+				relative('en-US', -2, 'year')
+			);
+		});
+
+		it('uses the provided locale', () => {
+			expect(formatRelativeTime('2026-07-18T10:28:00Z', 'it-IT', now)).toBe(
+				relative('it-IT', -2, 'minute')
+			);
 		});
 	});
 });

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -35,6 +35,9 @@ const ProfileSettingsPage = lazy(
 const ProfileStatsPage = lazy(
 	() => import('@/features/profile/pages/ProfileStatsPage')
 );
+const NotificationsPage = lazy(
+	() => import('@/features/notifications/pages/NotificationsPage')
+);
 
 export const AppRoutes = () => {
 	const authenticatedStatus = useAuthStore(
@@ -73,6 +76,11 @@ export const AppRoutes = () => {
 							path="/movies/:tmdbId"
 							id="movie-details"
 							element={<MovieDetailsPage />}
+						/>
+						<Route
+							path="/notifications"
+							id="notifications"
+							element={<NotificationsPage />}
 						/>
 						<Route path="/profile/:handle" element={<ProfilePage />}>
 							<Route index element={<ProfileOverviewPage />} />

--- a/src/routes/AppRoutes.unit.test.tsx
+++ b/src/routes/AppRoutes.unit.test.tsx
@@ -58,6 +58,9 @@ vi.mock('@/features/profile/pages/ProfileSettingsPage', () => ({
 vi.mock('@/features/profile/pages/ProfileStatsPage', () => ({
 	default: () => <div data-testid="profile-stats-page" />,
 }));
+vi.mock('@/features/notifications/pages/NotificationsPage', () => ({
+	default: () => <div data-testid="notifications-page" />,
+}));
 vi.mock('@antoniobenincasa/ui', () => ({
 	Spinner: () => <div data-testid="spinner" />,
 }));
@@ -84,6 +87,7 @@ describe('AppRoutes', () => {
 			import('@/features/profile/pages/ProfileMoviesWatchedPage'),
 			import('@/features/profile/pages/ProfileSettingsPage'),
 			import('@/features/profile/pages/ProfileStatsPage'),
+			import('@/features/notifications/pages/NotificationsPage'),
 		]);
 	});
 
@@ -175,6 +179,7 @@ describe('AppRoutes', () => {
 			['/profile/neo', 'profile-overview-page'],
 			['/profile/neo/movie-watched', 'profile-movies-page'],
 			['/profile/neo/stats', 'profile-stats-page'],
+			['/notifications', 'notifications-page'],
 		];
 
 		const renders = cases.map(([entry]) =>


### PR DESCRIPTION
## Summary
- Add an authenticated `/notifications` inbox that consumes `GET /v1/notifications` with unread filtering and cursor load-more.
- Add a navbar bell (no unread count) as the entry point; rows render title, body, and timestamp only.
- Keep read mutations, badge counts, and web push out of this slice.

Closes #89

## Test plan
- [x] Log in and confirm the navbar bell appears and opens `/notifications`.
- [x] Confirm the bell has no numeric unread badge.
- [x] Confirm the inbox lists notifications, supports unread-only filtering, and load-more pagination.
- [x] Confirm rows are inert (no links, buttons, or mark-as-read) and unread items show a dot plus stronger title.
- [x] Confirm loading, empty, filter-empty, error/retry, and load-more states are localized.
- [x] Confirm guests do not see the bell and `/notifications` redirects to login.


Made with [Cursor](https://cursor.com)