### PR TITLE
feat(notifications): localize inbox copy by type and actor

### DIFF
--- a/src/features/notifications/components/NotificationItem.tsx
+++ b/src/features/notifications/components/NotificationItem.tsx
@@ -1,23 +1,28 @@
+import type { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { formatRelativeTime } from '@/lib/utilities/date-utils';
-import type { NotificationBaseResponse } from '../models';
 
 type NotificationItemProps = {
-	notification: NotificationBaseResponse;
+	unread: boolean;
+	createdAt: string;
+	title: ReactNode;
 };
 
-export const NotificationItem = ({ notification }: NotificationItemProps) => {
+export const NotificationItem = ({
+	unread,
+	createdAt,
+	title,
+}: NotificationItemProps) => {
 	const { i18n } = useTranslation();
 	const locale = i18n.resolvedLanguage ?? i18n.language;
-	const isUnread = notification.readAt === null;
 
 	return (
 		<article
 			data-testid="notification-item"
-			data-unread={isUnread}
+			data-unread={unread}
 			className="flex items-start gap-3 rounded-xl border border-gray-200 p-4 dark:border-gray-800"
 		>
-			{isUnread ? (
+			{unread ? (
 				<span
 					data-testid="unread-dot"
 					aria-hidden="true"
@@ -29,21 +34,18 @@ export const NotificationItem = ({ notification }: NotificationItemProps) => {
 			<div className="flex min-w-0 flex-1 flex-col gap-1">
 				<h3
 					className={
-						isUnread
+						unread
 							? 'font-semibold text-gray-900 dark:text-white'
 							: 'font-normal text-gray-700 dark:text-gray-300'
 					}
 				>
-					{notification.title}
+					{title}
 				</h3>
-				<p className="text-sm text-gray-600 dark:text-gray-400">
-					{notification.body}
-				</p>
 				<time
-					dateTime={notification.createdAt}
+					dateTime={createdAt}
 					className="text-xs text-gray-500 dark:text-gray-500"
 				>
-					{formatRelativeTime(notification.createdAt, locale)}
+					{formatRelativeTime(createdAt, locale)}
 				</time>
 			</div>
 		</article>

--- a/src/features/notifications/components/NotificationItem.unit.test.tsx
+++ b/src/features/notifications/components/NotificationItem.unit.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import type { NotificationBaseResponse } from '../models';
 import { NotificationItem } from './NotificationItem';
 
 vi.mock('react-i18next', () => ({
@@ -10,30 +9,19 @@ vi.mock('react-i18next', () => ({
 	}),
 }));
 
-const unreadNotification: NotificationBaseResponse = {
-	id: 'n-1',
-	type: 'follow.started',
-	title: 'New follower',
-	body: 'A user started following you.',
-	actor: {
-		handle: 'moviefan',
-		firstName: 'Movie',
-		lastName: 'Fan',
-	},
-	availableActions: [],
-	readAt: null,
-	createdAt: '2026-07-18T10:30:00Z',
-};
+const createdAt = '2026-07-18T10:30:00Z';
 
 describe('NotificationItem', () => {
-	it('renders title, body, and timestamp without links or buttons', () => {
-		render(<NotificationItem notification={unreadNotification} />);
+	it('renders the provided title and timestamp without inventing links or buttons', () => {
+		render(
+			<NotificationItem
+				unread
+				title="You have a new follower"
+				createdAt={createdAt}
+			/>
+		);
 
-		expect(screen.getByText('New follower')).toBeInTheDocument();
-		expect(
-			screen.getByText('A user started following you.')
-		).toBeInTheDocument();
-		expect(screen.queryByText('Movie Fan')).not.toBeInTheDocument();
+		expect(screen.getByText('You have a new follower')).toBeInTheDocument();
 		expect(
 			document.querySelector('time[datetime="2026-07-18T10:30:00Z"]')
 		).toBeInTheDocument();
@@ -42,23 +30,24 @@ describe('NotificationItem', () => {
 	});
 
 	it('marks unread items with a dot and stronger title', () => {
-		render(<NotificationItem notification={unreadNotification} />);
+		render(
+			<NotificationItem unread title="Unread title" createdAt={createdAt} />
+		);
 
 		expect(screen.getByTestId('unread-dot')).toBeInTheDocument();
-		expect(screen.getByText('New follower')).toHaveClass('font-semibold');
+		expect(screen.getByRole('heading')).toHaveClass('font-semibold');
 	});
 
 	it('renders read items without a dot and with a quieter title', () => {
 		render(
 			<NotificationItem
-				notification={{
-					...unreadNotification,
-					readAt: '2026-07-18T11:00:00Z',
-				}}
+				unread={false}
+				title="Read title"
+				createdAt={createdAt}
 			/>
 		);
 
 		expect(screen.queryByTestId('unread-dot')).not.toBeInTheDocument();
-		expect(screen.getByText('New follower')).not.toHaveClass('font-semibold');
+		expect(screen.getByRole('heading')).not.toHaveClass('font-semibold');
 	});
 });

--- a/src/features/notifications/components/NotificationList.tsx
+++ b/src/features/notifications/components/NotificationList.tsx
@@ -1,7 +1,7 @@
 import { Button, Spinner } from '@antoniobenincasa/ui';
 import { useTranslation } from 'react-i18next';
 import { useNotificationsStore } from '../stores';
-import { NotificationItem } from './NotificationItem';
+import { NotificationListItem } from './NotificationListItem';
 import { NotificationsEmptyState } from './NotificationsEmptyState';
 
 export const NotificationList = () => {
@@ -49,7 +49,10 @@ export const NotificationList = () => {
 	return (
 		<div className="flex flex-col gap-3">
 			{items.map((notification) => (
-				<NotificationItem key={notification.id} notification={notification} />
+				<NotificationListItem
+					key={notification.id}
+					notification={notification}
+				/>
 			))}
 
 			{error ? (

--- a/src/features/notifications/components/NotificationListItem.tsx
+++ b/src/features/notifications/components/NotificationListItem.tsx
@@ -1,0 +1,37 @@
+import { Trans, useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import type { NotificationBaseResponse } from '../models';
+import { resolveNotificationView } from '../utilities/resolve-notification-view';
+import { NotificationItem } from './NotificationItem';
+
+type NotificationListItemProps = {
+	notification: NotificationBaseResponse;
+};
+
+export const NotificationListItem = ({
+	notification,
+}: NotificationListItemProps) => {
+	const { t } = useTranslation();
+	const { copyKey, interpolation, actorHref } =
+		resolveNotificationView(notification);
+
+	const title = actorHref ? (
+		<Trans
+			i18nKey={copyKey}
+			values={interpolation}
+			components={{
+				actor: <Link to={actorHref} className="hover:underline" />,
+			}}
+		/>
+	) : (
+		t(copyKey)
+	);
+
+	return (
+		<NotificationItem
+			unread={notification.readAt === null}
+			createdAt={notification.createdAt}
+			title={title}
+		/>
+	);
+};

--- a/src/features/notifications/components/NotificationListItem.unit.test.tsx
+++ b/src/features/notifications/components/NotificationListItem.unit.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from '@testing-library/react';
+import { cloneElement, type ReactElement } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import type { NotificationBaseResponse } from '../models';
+import { NotificationListItem } from './NotificationListItem';
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({
+		t: (key: string) => key,
+		i18n: { language: 'en-US', resolvedLanguage: 'en-US' },
+	}),
+	Trans: ({
+		i18nKey,
+		values,
+		components,
+	}: {
+		i18nKey: string;
+		values?: { firstName?: string; lastName?: string };
+		components?: { actor?: ReactElement };
+	}) => {
+		const name = `${values?.firstName ?? ''} ${values?.lastName ?? ''}`.trim();
+
+		return (
+			<>
+				{components?.actor
+					? cloneElement(components.actor, undefined, name)
+					: name}
+				{i18nKey}
+			</>
+		);
+	},
+}));
+
+const unreadNotification: NotificationBaseResponse = {
+	id: 'n-1',
+	type: 'follow.started',
+	title: 'New follower',
+	body: 'A user started following you.',
+	actor: {
+		handle: 'moviefan',
+		firstName: 'Movie',
+		lastName: 'Fan',
+	},
+	availableActions: [],
+	readAt: null,
+	createdAt: '2026-07-18T10:30:00Z',
+};
+
+const renderItem = (notification: NotificationBaseResponse) =>
+	render(
+		<MemoryRouter>
+			<NotificationListItem notification={notification} />
+		</MemoryRouter>
+	);
+
+describe('NotificationListItem', () => {
+	it('renders localized copy with the actor name linked to the profile', () => {
+		renderItem(unreadNotification);
+
+		expect(screen.getByRole('link', { name: 'Movie Fan' })).toHaveAttribute(
+			'href',
+			'/profile/moviefan'
+		);
+		expect(
+			screen.getByText('NotificationItem.follow.started.withActor')
+		).toBeInTheDocument();
+		expect(screen.queryByText('New follower')).not.toBeInTheDocument();
+		expect(
+			screen.queryByText('A user started following you.')
+		).not.toBeInTheDocument();
+		expect(
+			document.querySelector('time[datetime="2026-07-18T10:30:00Z"]')
+		).toBeInTheDocument();
+		expect(screen.queryByRole('button')).not.toBeInTheDocument();
+	});
+
+	it('renders type-only copy with no link when the actor is missing', () => {
+		renderItem({ ...unreadNotification, actor: null });
+
+		expect(
+			screen.getByText('NotificationItem.follow.started.noActor')
+		).toBeInTheDocument();
+		expect(screen.queryByRole('link')).not.toBeInTheDocument();
+		expect(screen.queryByText('Movie Fan')).not.toBeInTheDocument();
+	});
+});

--- a/src/features/notifications/pages/NotificationsPage.integration.test.tsx
+++ b/src/features/notifications/pages/NotificationsPage.integration.test.tsx
@@ -63,7 +63,7 @@ const secondItem = {
 const unreadItem = {
 	...firstItem,
 	id: 'n-unread',
-	title: 'Unread only item',
+	type: 'follow.requested' as const,
 };
 
 describe('NotificationsPage list flow', () => {
@@ -101,21 +101,31 @@ describe('NotificationsPage list flow', () => {
 
 		render(<NotificationsPage />);
 
-		expect(await screen.findByText('New follower')).toBeInTheDocument();
+		expect(
+			await screen.findByText('NotificationItem.follow.started.noActor')
+		).toBeInTheDocument();
 		expect(mockListNotifications).toHaveBeenCalledWith({ unreadOnly: false });
 
 		fireEvent.click(screen.getByText('NotificationsPage.unreadOnly'));
 
-		expect(await screen.findByText('Unread only item')).toBeInTheDocument();
-		expect(screen.queryByText('New follower')).not.toBeInTheDocument();
+		expect(
+			await screen.findByText('NotificationItem.follow.requested.noActor')
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText('NotificationItem.follow.started.noActor')
+		).not.toBeInTheDocument();
 		expect(mockListNotifications).toHaveBeenCalledWith({ unreadOnly: true });
 
 		fireEvent.click(screen.getByText('NotificationsPage.loadMore'));
 
 		await waitFor(() => {
-			expect(screen.getByText('Follow accepted')).toBeInTheDocument();
+			expect(
+				screen.getByText('NotificationItem.follow.accepted.noActor')
+			).toBeInTheDocument();
 		});
-		expect(screen.getByText('Unread only item')).toBeInTheDocument();
+		expect(
+			screen.getByText('NotificationItem.follow.requested.noActor')
+		).toBeInTheDocument();
 		expect(mockListNotifications).toHaveBeenCalledWith({
 			unreadOnly: true,
 			cursor: 'unread-cursor',

--- a/src/features/notifications/pages/NotificationsPage.unit.test.tsx
+++ b/src/features/notifications/pages/NotificationsPage.unit.test.tsx
@@ -130,7 +130,9 @@ describe('NotificationsPage', () => {
 
 		render(<NotificationsPage />);
 
-		expect(screen.getByText('New follower')).toBeInTheDocument();
+		expect(
+			screen.getByText('NotificationItem.follow.started.noActor')
+		).toBeInTheDocument();
 		fireEvent.click(screen.getByText('NotificationsPage.loadMore'));
 		expect(mockLoadMore).toHaveBeenCalledOnce();
 	});

--- a/src/features/notifications/utilities/resolve-notification-view.ts
+++ b/src/features/notifications/utilities/resolve-notification-view.ts
@@ -1,0 +1,15 @@
+import type { NotificationBaseResponse } from '../models';
+
+export const resolveNotificationView = (
+	notification: NotificationBaseResponse
+) => {
+	const actor = notification.actor;
+
+	return {
+		copyKey: `NotificationItem.${notification.type}.${actor ? 'withActor' : 'noActor'}`,
+		interpolation: actor
+			? { firstName: actor.firstName, lastName: actor.lastName }
+			: undefined,
+		actorHref: actor ? `/profile/${actor.handle}` : null,
+	};
+};

--- a/src/features/notifications/utilities/resolve-notification-view.unit.test.ts
+++ b/src/features/notifications/utilities/resolve-notification-view.unit.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import type { NotificationBaseResponse } from '../models';
+import { NOTIFICATION_TYPE_VALUES } from '../models';
+import { resolveNotificationView } from './resolve-notification-view';
+
+const actor = {
+	handle: 'moviefan',
+	firstName: 'Movie',
+	lastName: 'Fan',
+};
+
+const baseNotification: NotificationBaseResponse = {
+	id: 'n-1',
+	type: 'follow.started',
+	title: 'New follower',
+	body: 'A user started following you.',
+	actor,
+	availableActions: [],
+	readAt: null,
+	createdAt: '2026-07-18T10:30:00Z',
+};
+
+describe('resolveNotificationView', () => {
+	it.each(
+		NOTIFICATION_TYPE_VALUES
+	)('resolves %s with an actor to copy and profile href', (type) => {
+		expect(resolveNotificationView({ ...baseNotification, type })).toEqual({
+			copyKey: `NotificationItem.${type}.withActor`,
+			interpolation: { firstName: 'Movie', lastName: 'Fan' },
+			actorHref: '/profile/moviefan',
+		});
+	});
+
+	it.each(
+		NOTIFICATION_TYPE_VALUES
+	)('resolves %s without an actor to type-only copy', (type) => {
+		expect(
+			resolveNotificationView({ ...baseNotification, type, actor: null })
+		).toEqual({
+			copyKey: `NotificationItem.${type}.noActor`,
+			interpolation: undefined,
+			actorHref: null,
+		});
+	});
+});

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -368,5 +368,21 @@
 		"error": "Failed to load notifications",
 		"retry": "Try again",
 		"loadMore": "Load more"
+	},
+	"NotificationItem": {
+		"follow": {
+			"started": {
+				"withActor": "<actor>{{firstName}} {{lastName}}</actor> started following you",
+				"noActor": "You have a new follower"
+			},
+			"requested": {
+				"withActor": "<actor>{{firstName}} {{lastName}}</actor> requested to follow you",
+				"noActor": "You have a new follow request"
+			},
+			"accepted": {
+				"withActor": "<actor>{{firstName}} {{lastName}}</actor> accepted your follow request",
+				"noActor": "Your follow request was accepted"
+			}
+		}
 	}
 }

--- a/src/lib/locales/fr.json
+++ b/src/lib/locales/fr.json
@@ -368,5 +368,21 @@
 		"error": "Impossible de charger les notifications",
 		"retry": "Réessayer",
 		"loadMore": "Charger plus"
+	},
+	"NotificationItem": {
+		"follow": {
+			"started": {
+				"withActor": "<actor>{{firstName}} {{lastName}}</actor> a commencé à vous suivre",
+				"noActor": "Vous avez un nouvel abonné"
+			},
+			"requested": {
+				"withActor": "<actor>{{firstName}} {{lastName}}</actor> a demandé à vous suivre",
+				"noActor": "Vous avez une nouvelle demande d'abonnement"
+			},
+			"accepted": {
+				"withActor": "<actor>{{firstName}} {{lastName}}</actor> a accepté votre demande d'abonnement",
+				"noActor": "Votre demande d'abonnement a été acceptée"
+			}
+		}
 	}
 }

--- a/src/lib/locales/it.json
+++ b/src/lib/locales/it.json
@@ -368,5 +368,21 @@
 		"error": "Impossibile caricare le notifiche",
 		"retry": "Riprova",
 		"loadMore": "Carica altri"
+	},
+	"NotificationItem": {
+		"follow": {
+			"started": {
+				"withActor": "<actor>{{firstName}} {{lastName}}</actor> ha iniziato a seguirti",
+				"noActor": "Hai un nuovo follower"
+			},
+			"requested": {
+				"withActor": "<actor>{{firstName}} {{lastName}}</actor> ha chiesto di seguirti",
+				"noActor": "Hai una nuova richiesta di follow"
+			},
+			"accepted": {
+				"withActor": "<actor>{{firstName}} {{lastName}}</actor> ha accettato la tua richiesta di follow",
+				"noActor": "La tua richiesta di follow è stata accettata"
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Render a localized sentence from notification `type` instead of API `title`/`body`.
- When an actor is present, interpolate `{firstName} {lastName}` and link the name to `/profile/:handle`.
- When the actor is missing, show type-only copy with no link. Accept/Reject stays out of this slice.
- `NotificationItem` is a presentational shell. An exhaustive type registry builds the view model; `NotificationListItem` composes Trans, the profile link, and the shell.

Closes #91

## Test plan
- [ ] Open `/notifications` with a `follow.started` item that has an actor and confirm the sentence uses the actor name.
- [ ] Click the actor name and land on `/profile/:handle`.
- [ ] Confirm a notification with `actor: null` shows type-only copy and is not a link.
- [ ] Switch locale to Italian and French and confirm the sentence translates.
- [ ] Confirm unread styling and relative timestamps still work.
- [ ] Confirm Accept/Reject buttons are not shown.