### PR TITLE
feat(notifications): support individual and bulk read actions

### DIFF
--- a/src/features/notifications/components/NotificationItem.tsx
+++ b/src/features/notifications/components/NotificationItem.tsx
@@ -6,12 +6,14 @@ type NotificationItemProps = {
 	unread: boolean;
 	createdAt: string;
 	title: ReactNode;
+	action?: ReactNode;
 };
 
 export const NotificationItem = ({
 	unread,
 	createdAt,
 	title,
+	action,
 }: NotificationItemProps) => {
 	const { i18n } = useTranslation();
 	const locale = i18n.resolvedLanguage ?? i18n.language;
@@ -48,6 +50,7 @@ export const NotificationItem = ({
 					{formatRelativeTime(createdAt, locale)}
 				</time>
 			</div>
+			{action}
 		</article>
 	);
 };

--- a/src/features/notifications/components/NotificationItem.unit.test.tsx
+++ b/src/features/notifications/components/NotificationItem.unit.test.tsx
@@ -50,4 +50,19 @@ describe('NotificationItem', () => {
 		expect(screen.queryByTestId('unread-dot')).not.toBeInTheDocument();
 		expect(screen.getByRole('heading')).not.toHaveClass('font-semibold');
 	});
+
+	it('renders an optional explicit action', () => {
+		render(
+			<NotificationItem
+				unread
+				title="Unread title"
+				createdAt={createdAt}
+				action={<button type="button">Mark as read</button>}
+			/>
+		);
+
+		expect(
+			screen.getByRole('button', { name: 'Mark as read' })
+		).toBeInTheDocument();
+	});
 });

--- a/src/features/notifications/components/NotificationListItem.tsx
+++ b/src/features/notifications/components/NotificationListItem.tsx
@@ -1,6 +1,8 @@
+import { Button, useNotification } from '@antoniobenincasa/ui';
 import { Trans, useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import type { NotificationBaseResponse } from '../models';
+import { useNotificationsStore } from '../stores';
 import { resolveNotificationView } from '../utilities/resolve-notification-view';
 import { NotificationItem } from './NotificationItem';
 
@@ -12,8 +14,27 @@ export const NotificationListItem = ({
 	notification,
 }: NotificationListItemProps) => {
 	const { t } = useTranslation();
+	const { notify } = useNotification();
+	const pendingReadId = useNotificationsStore((state) => state.pendingReadId);
+	const isMarkingAllRead = useNotificationsStore(
+		(state) => state.isMarkingAllRead
+	);
+	const markAsRead = useNotificationsStore((state) => state.markAsRead);
 	const { copyKey, interpolation, actorHref } =
 		resolveNotificationView(notification);
+	const isUnread = notification.readAt === null;
+	const isPending = pendingReadId === notification.id;
+
+	const handleMarkAsRead = async () => {
+		try {
+			await markAsRead(notification.id);
+		} catch {
+			notify({
+				variant: 'danger',
+				message: t('NotificationItem.markAsReadError'),
+			});
+		}
+	};
 
 	const title = actorHref ? (
 		<Trans
@@ -29,9 +50,22 @@ export const NotificationListItem = ({
 
 	return (
 		<NotificationItem
-			unread={notification.readAt === null}
+			unread={isUnread}
 			createdAt={notification.createdAt}
 			title={title}
+			action={
+				isUnread ? (
+					<Button
+						type="button"
+						variant="outline"
+						disabled={pendingReadId !== null || isMarkingAllRead}
+						aria-busy={isPending}
+						onClick={handleMarkAsRead}
+					>
+						{t('NotificationItem.markAsRead')}
+					</Button>
+				) : undefined
+			}
 		/>
 	);
 };

--- a/src/features/notifications/components/NotificationListItem.unit.test.tsx
+++ b/src/features/notifications/components/NotificationListItem.unit.test.tsx
@@ -1,9 +1,49 @@
-import { render, screen } from '@testing-library/react';
-import { cloneElement, type ReactElement } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cloneElement, type ReactElement, type ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { NotificationBaseResponse } from '../models';
 import { NotificationListItem } from './NotificationListItem';
+
+const { mockMarkAsRead, mockNotify, notificationStoreState } = vi.hoisted(
+	() => ({
+		mockMarkAsRead: vi.fn(),
+		mockNotify: vi.fn(),
+		notificationStoreState: {
+			pendingReadId: null as string | null,
+			isMarkingAllRead: false,
+			markAsRead: vi.fn(),
+		},
+	})
+);
+
+notificationStoreState.markAsRead = mockMarkAsRead;
+
+vi.mock('../stores', () => ({
+	useNotificationsStore: (
+		selector: (state: typeof notificationStoreState) => unknown
+	) => selector(notificationStoreState),
+}));
+
+vi.mock('@antoniobenincasa/ui', () => ({
+	Button: ({
+		children,
+		onClick,
+		disabled,
+		variant: _variant,
+		...props
+	}: {
+		children?: ReactNode;
+		onClick?: () => void;
+		disabled?: boolean;
+		variant?: string;
+	} & Record<string, unknown>) => (
+		<button type="button" onClick={onClick} disabled={disabled} {...props}>
+			{children}
+		</button>
+	),
+	useNotification: () => ({ notify: mockNotify }),
+}));
 
 vi.mock('react-i18next', () => ({
 	useTranslation: () => ({
@@ -55,6 +95,13 @@ const renderItem = (notification: NotificationBaseResponse) =>
 	);
 
 describe('NotificationListItem', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		notificationStoreState.pendingReadId = null;
+		notificationStoreState.isMarkingAllRead = false;
+		mockMarkAsRead.mockResolvedValue(undefined);
+	});
+
 	it('renders localized copy with the actor name linked to the profile', () => {
 		renderItem(unreadNotification);
 
@@ -72,7 +119,9 @@ describe('NotificationListItem', () => {
 		expect(
 			document.querySelector('time[datetime="2026-07-18T10:30:00Z"]')
 		).toBeInTheDocument();
-		expect(screen.queryByRole('button')).not.toBeInTheDocument();
+		expect(
+			screen.getByRole('button', { name: 'NotificationItem.markAsRead' })
+		).toBeInTheDocument();
 	});
 
 	it('renders type-only copy with no link when the actor is missing', () => {
@@ -83,5 +132,71 @@ describe('NotificationListItem', () => {
 		).toBeInTheDocument();
 		expect(screen.queryByRole('link')).not.toBeInTheDocument();
 		expect(screen.queryByText('Movie Fan')).not.toBeInTheDocument();
+	});
+
+	it('marks an unread notification read from an explicit text button', async () => {
+		renderItem(unreadNotification);
+
+		fireEvent.click(
+			screen.getByRole('button', { name: 'NotificationItem.markAsRead' })
+		);
+
+		await waitFor(() => {
+			expect(mockMarkAsRead).toHaveBeenCalledWith('n-1');
+		});
+		expect(mockNotify).not.toHaveBeenCalled();
+	});
+
+	it('does not render a read control for an already-read notification', () => {
+		renderItem({
+			...unreadNotification,
+			readAt: '2026-07-18T11:00:00Z',
+		});
+
+		expect(
+			screen.queryByRole('button', { name: 'NotificationItem.markAsRead' })
+		).not.toBeInTheDocument();
+	});
+
+	it('disables and exposes busy state while a read mutation is pending', () => {
+		notificationStoreState.pendingReadId = 'n-1';
+
+		renderItem(unreadNotification);
+
+		expect(
+			screen.getByRole('button', { name: 'NotificationItem.markAsRead' })
+		).toBeDisabled();
+		expect(
+			screen.getByRole('button', { name: 'NotificationItem.markAsRead' })
+		).toHaveAttribute('aria-busy', 'true');
+	});
+
+	it('disables individual reads during a bulk mutation', () => {
+		notificationStoreState.isMarkingAllRead = true;
+
+		renderItem(unreadNotification);
+
+		expect(
+			screen.getByRole('button', { name: 'NotificationItem.markAsRead' })
+		).toBeDisabled();
+	});
+
+	it('shows localized danger feedback and permits retry after failure', async () => {
+		mockMarkAsRead.mockRejectedValueOnce(new Error('Read failed'));
+		renderItem(unreadNotification);
+
+		fireEvent.click(
+			screen.getByRole('button', { name: 'NotificationItem.markAsRead' })
+		);
+
+		await waitFor(() => {
+			expect(mockNotify).toHaveBeenCalledWith({
+				variant: 'danger',
+				message: 'NotificationItem.markAsReadError',
+			});
+		});
+		expect(
+			screen.getByRole('button', { name: 'NotificationItem.markAsRead' })
+		).toBeEnabled();
 	});
 });

--- a/src/features/notifications/models/index.ts
+++ b/src/features/notifications/models/index.ts
@@ -1,4 +1,5 @@
 export type {
+	MarkAllNotificationsReadResponse,
 	NotificationActor,
 	NotificationBaseResponse,
 	NotificationListRequest,

--- a/src/features/notifications/models/notification.ts
+++ b/src/features/notifications/models/notification.ts
@@ -24,6 +24,11 @@ export type NotificationListResponse = {
 	unreadCount: number;
 };
 
+export type MarkAllNotificationsReadResponse = {
+	updatedCount: number;
+	unreadCount: number;
+};
+
 export type NotificationListRequest = {
 	unreadOnly?: boolean;
 	limit?: number;

--- a/src/features/notifications/pages/NotificationsPage.integration.test.tsx
+++ b/src/features/notifications/pages/NotificationsPage.integration.test.tsx
@@ -2,12 +2,24 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockListNotifications } = vi.hoisted(() => ({
+const {
+	mockListNotifications,
+	mockMarkNotificationRead,
+	mockMarkAllNotificationsRead,
+	mockNotify,
+} = vi.hoisted(() => ({
 	mockListNotifications: vi.fn(),
+	mockMarkNotificationRead: vi.fn(),
+	mockMarkAllNotificationsRead: vi.fn(),
+	mockNotify: vi.fn(),
 }));
 
 vi.mock('../repositories/notifications-repository', () => ({
 	listNotifications: (...args: unknown[]) => mockListNotifications(...args),
+	markNotificationRead: (...args: unknown[]) =>
+		mockMarkNotificationRead(...args),
+	markAllNotificationsRead: (...args: unknown[]) =>
+		mockMarkAllNotificationsRead(...args),
 }));
 
 vi.mock('react-i18next', () => ({
@@ -33,6 +45,7 @@ vi.mock('@antoniobenincasa/ui', () => ({
 		</button>
 	),
 	Spinner: () => <div data-testid="spinner" />,
+	useNotification: () => ({ notify: mockNotify }),
 }));
 
 import { useNotificationsStore } from '../stores';
@@ -76,6 +89,8 @@ describe('NotificationsPage list flow', () => {
 			unreadOnly: false,
 			isLoading: false,
 			isLoadingMore: false,
+			pendingReadId: null,
+			isMarkingAllRead: false,
 			error: null,
 			hasLoaded: false,
 		});
@@ -133,5 +148,134 @@ describe('NotificationsPage list flow', () => {
 		expect(
 			screen.queryByText('NotificationsPage.loadMore')
 		).not.toBeInTheDocument();
+	});
+
+	it('marks one notification read using the exact server response', async () => {
+		const readAt = '2026-07-18T12:34:56Z';
+		mockListNotifications.mockResolvedValueOnce({
+			items: [firstItem],
+			nextCursor: null,
+			unreadCount: 1,
+		});
+		mockMarkNotificationRead.mockResolvedValueOnce({ ...firstItem, readAt });
+
+		render(<NotificationsPage />);
+
+		fireEvent.click(
+			await screen.findByRole('button', {
+				name: 'NotificationItem.markAsRead',
+			})
+		);
+
+		await waitFor(() => {
+			expect(
+				screen.queryByRole('button', {
+					name: 'NotificationItem.markAsRead',
+				})
+			).not.toBeInTheDocument();
+		});
+		expect(mockMarkNotificationRead).toHaveBeenCalledWith('n-1');
+		expect(useNotificationsStore.getState().items[0].readAt).toBe(readAt);
+		expect(useNotificationsStore.getState().unreadCount).toBe(0);
+		expect(mockNotify).not.toHaveBeenCalled();
+	});
+
+	it('removes an individually read notification from the unread-only view', async () => {
+		mockListNotifications
+			.mockResolvedValueOnce({
+				items: [firstItem],
+				nextCursor: null,
+				unreadCount: 1,
+			})
+			.mockResolvedValueOnce({
+				items: [firstItem],
+				nextCursor: null,
+				unreadCount: 1,
+			});
+		mockMarkNotificationRead.mockResolvedValueOnce({
+			...firstItem,
+			readAt: '2026-07-18T12:34:56Z',
+		});
+
+		render(<NotificationsPage />);
+		await screen.findByText('NotificationItem.follow.started.noActor');
+		fireEvent.click(screen.getByText('NotificationsPage.unreadOnly'));
+		await waitFor(() => expect(mockListNotifications).toHaveBeenCalledTimes(2));
+
+		fireEvent.click(
+			screen.getByRole('button', { name: 'NotificationItem.markAsRead' })
+		);
+
+		expect(
+			await screen.findByText('NotificationsPage.emptyUnread')
+		).toBeInTheDocument();
+	});
+
+	it('marks all notifications read and reloads the first page', async () => {
+		const readItems = [firstItem, unreadItem].map((item) => ({
+			...item,
+			readAt: '2026-07-18T12:34:56Z',
+		}));
+		mockListNotifications
+			.mockResolvedValueOnce({
+				items: [firstItem, unreadItem],
+				nextCursor: 'cursor-1',
+				unreadCount: 2,
+			})
+			.mockResolvedValueOnce({
+				items: readItems,
+				nextCursor: null,
+				unreadCount: 0,
+			});
+		mockMarkAllNotificationsRead.mockResolvedValueOnce({
+			updatedCount: 2,
+			unreadCount: 0,
+		});
+
+		render(<NotificationsPage />);
+		fireEvent.click(
+			await screen.findByRole('button', {
+				name: 'NotificationsPage.markAllAsRead',
+			})
+		);
+
+		await waitFor(() => expect(mockListNotifications).toHaveBeenCalledTimes(2));
+		expect(mockMarkAllNotificationsRead).toHaveBeenCalledOnce();
+		expect(useNotificationsStore.getState()).toMatchObject({
+			items: readItems,
+			nextCursor: null,
+			unreadCount: 0,
+		});
+		expect(
+			screen.queryByRole('button', {
+				name: 'NotificationsPage.markAllAsRead',
+			})
+		).not.toBeInTheDocument();
+	});
+
+	it('shows retryable danger feedback when an individual read fails', async () => {
+		mockListNotifications.mockResolvedValueOnce({
+			items: [firstItem],
+			nextCursor: null,
+			unreadCount: 1,
+		});
+		mockMarkNotificationRead.mockRejectedValueOnce(new Error('Read failed'));
+
+		render(<NotificationsPage />);
+		fireEvent.click(
+			await screen.findByRole('button', {
+				name: 'NotificationItem.markAsRead',
+			})
+		);
+
+		await waitFor(() => {
+			expect(mockNotify).toHaveBeenCalledWith({
+				variant: 'danger',
+				message: 'NotificationItem.markAsReadError',
+			});
+		});
+		expect(
+			screen.getByRole('button', { name: 'NotificationItem.markAsRead' })
+		).toBeEnabled();
 	});
 });

--- a/src/features/notifications/pages/NotificationsPage.tsx
+++ b/src/features/notifications/pages/NotificationsPage.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@antoniobenincasa/ui';
+import { Button, useNotification } from '@antoniobenincasa/ui';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { NotificationList } from '../components';
@@ -6,12 +6,30 @@ import { useNotificationsStore } from '../stores';
 
 const NotificationsPage = () => {
 	const { t } = useTranslation();
+	const { notify } = useNotification();
 	const unreadOnly = useNotificationsStore((state) => state.unreadOnly);
+	const unreadCount = useNotificationsStore((state) => state.unreadCount);
+	const pendingReadId = useNotificationsStore((state) => state.pendingReadId);
+	const isMarkingAllRead = useNotificationsStore(
+		(state) => state.isMarkingAllRead
+	);
 	const loadNotifications = useNotificationsStore(
 		(state) => state.loadNotifications
 	);
 	const setUnreadOnly = useNotificationsStore((state) => state.setUnreadOnly);
+	const markAllAsRead = useNotificationsStore((state) => state.markAllAsRead);
 	const reset = useNotificationsStore((state) => state.reset);
+
+	const handleMarkAllAsRead = async () => {
+		try {
+			await markAllAsRead();
+		} catch {
+			notify({
+				variant: 'danger',
+				message: t('NotificationsPage.markAllAsReadError'),
+			});
+		}
+	};
 
 	useEffect(() => {
 		loadNotifications();
@@ -25,16 +43,29 @@ const NotificationsPage = () => {
 		<>
 			<title>{t('NotificationsPage.pageTitle')}</title>
 			<div className="mx-auto flex w-full max-w-2xl flex-col gap-6">
-				<div className="flex items-center justify-between gap-4">
+				<div className="flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
 					<h1 className="text-2xl font-bold">{t('NotificationsPage.title')}</h1>
-					<Button
-						type="button"
-						variant={unreadOnly ? 'default' : 'outline'}
-						aria-pressed={unreadOnly}
-						onClick={() => setUnreadOnly(!unreadOnly)}
-					>
-						{t('NotificationsPage.unreadOnly')}
-					</Button>
+					<div className="flex flex-wrap gap-2">
+						{unreadCount > 0 ? (
+							<Button
+								type="button"
+								variant="outline"
+								disabled={pendingReadId !== null || isMarkingAllRead}
+								aria-busy={isMarkingAllRead}
+								onClick={handleMarkAllAsRead}
+							>
+								{t('NotificationsPage.markAllAsRead')}
+							</Button>
+						) : null}
+						<Button
+							type="button"
+							variant={unreadOnly ? 'default' : 'outline'}
+							aria-pressed={unreadOnly}
+							onClick={() => setUnreadOnly(!unreadOnly)}
+						>
+							{t('NotificationsPage.unreadOnly')}
+						</Button>
+					</div>
 				</div>
 				<NotificationList />
 			</div>

--- a/src/features/notifications/pages/NotificationsPage.unit.test.tsx
+++ b/src/features/notifications/pages/NotificationsPage.unit.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { NotificationBaseResponse } from '../models';
@@ -6,19 +6,25 @@ import type { NotificationBaseResponse } from '../models';
 const mockLoadNotifications = vi.fn();
 const mockLoadMore = vi.fn();
 const mockSetUnreadOnly = vi.fn();
+const mockMarkAllAsRead = vi.fn();
 const mockReset = vi.fn();
+const mockNotify = vi.fn();
 
 const storeState = {
 	items: [] as NotificationBaseResponse[],
 	nextCursor: null as string | null,
+	unreadCount: 0,
 	unreadOnly: false,
 	isLoading: false,
 	isLoadingMore: false,
+	pendingReadId: null as string | null,
+	isMarkingAllRead: false,
 	error: null as string | null,
 	hasLoaded: false,
 	loadNotifications: mockLoadNotifications,
 	loadMore: mockLoadMore,
 	setUnreadOnly: mockSetUnreadOnly,
+	markAllAsRead: mockMarkAllAsRead,
 	reset: mockReset,
 };
 
@@ -50,6 +56,7 @@ vi.mock('@antoniobenincasa/ui', () => ({
 		</button>
 	),
 	Spinner: () => <div data-testid="spinner" />,
+	useNotification: () => ({ notify: mockNotify }),
 }));
 
 import NotificationsPage from './NotificationsPage';
@@ -70,11 +77,15 @@ describe('NotificationsPage', () => {
 		vi.clearAllMocks();
 		storeState.items = [];
 		storeState.nextCursor = null;
+		storeState.unreadCount = 0;
 		storeState.unreadOnly = false;
 		storeState.isLoading = false;
 		storeState.isLoadingMore = false;
+		storeState.pendingReadId = null;
+		storeState.isMarkingAllRead = false;
 		storeState.error = null;
 		storeState.hasLoaded = false;
+		mockMarkAllAsRead.mockResolvedValue(undefined);
 	});
 
 	it('loads notifications on mount and resets on unmount', () => {
@@ -144,5 +155,66 @@ describe('NotificationsPage', () => {
 
 		fireEvent.click(screen.getByText('NotificationsPage.unreadOnly'));
 		expect(mockSetUnreadOnly).toHaveBeenCalledWith(true);
+	});
+
+	it('marks all notifications read from an immediate text control', async () => {
+		storeState.hasLoaded = true;
+		storeState.items = [sampleItem];
+		storeState.unreadCount = 1;
+
+		render(<NotificationsPage />);
+
+		fireEvent.click(
+			screen.getByRole('button', { name: 'NotificationsPage.markAllAsRead' })
+		);
+
+		await waitFor(() => {
+			expect(mockMarkAllAsRead).toHaveBeenCalledOnce();
+		});
+		expect(mockNotify).not.toHaveBeenCalled();
+	});
+
+	it('hides the bulk control when there are no unread notifications', () => {
+		storeState.hasLoaded = true;
+
+		render(<NotificationsPage />);
+
+		expect(
+			screen.queryByRole('button', {
+				name: 'NotificationsPage.markAllAsRead',
+			})
+		).not.toBeInTheDocument();
+	});
+
+	it('disables the bulk control while a read mutation is pending', () => {
+		storeState.hasLoaded = true;
+		storeState.items = [sampleItem];
+		storeState.unreadCount = 1;
+		storeState.pendingReadId = 'n-1';
+
+		render(<NotificationsPage />);
+
+		expect(
+			screen.getByRole('button', { name: 'NotificationsPage.markAllAsRead' })
+		).toBeDisabled();
+	});
+
+	it('shows localized danger feedback and permits bulk retry after failure', async () => {
+		mockMarkAllAsRead.mockRejectedValueOnce(new Error('Bulk failed'));
+		storeState.hasLoaded = true;
+		storeState.items = [sampleItem];
+		storeState.unreadCount = 1;
+
+		render(<NotificationsPage />);
+		fireEvent.click(
+			screen.getByRole('button', { name: 'NotificationsPage.markAllAsRead' })
+		);
+
+		await waitFor(() => {
+			expect(mockNotify).toHaveBeenCalledWith({
+				variant: 'danger',
+				message: 'NotificationsPage.markAllAsReadError',
+			});
+		});
 	});
 });

--- a/src/features/notifications/repositories/index.ts
+++ b/src/features/notifications/repositories/index.ts
@@ -1,4 +1,6 @@
 export {
 	DEFAULT_NOTIFICATION_PAGE_SIZE,
 	listNotifications,
+	markAllNotificationsRead,
+	markNotificationRead,
 } from './notifications-repository';

--- a/src/features/notifications/repositories/notifications-repository.ts
+++ b/src/features/notifications/repositories/notifications-repository.ts
@@ -1,9 +1,15 @@
 import { apiClient } from '@/lib/api/client';
 import type {
+	MarkAllNotificationsReadResponse,
+	NotificationBaseResponse,
 	NotificationListRequest,
 	NotificationListResponse,
 } from '../models';
-import { parseNotificationListResponse } from '../schemas';
+import {
+	notificationItemSchema,
+	parseMarkAllNotificationsReadResponse,
+	parseNotificationListResponse,
+} from '../schemas';
 
 export const DEFAULT_NOTIFICATION_PAGE_SIZE = 20;
 
@@ -27,3 +33,20 @@ export const listNotifications = async (
 
 	return parseNotificationListResponse(json);
 };
+
+export const markNotificationRead = async (
+	notificationId: string
+): Promise<NotificationBaseResponse> => {
+	const json = await apiClient
+		.patch(`v1/notifications/${notificationId}/read`)
+		.json();
+
+	return notificationItemSchema.parse(json);
+};
+
+export const markAllNotificationsRead =
+	async (): Promise<MarkAllNotificationsReadResponse> => {
+		const json = await apiClient.post('v1/notifications/read-all').json();
+
+		return parseMarkAllNotificationsReadResponse(json);
+	};

--- a/src/features/notifications/repositories/notifications-repository.unit.test.ts
+++ b/src/features/notifications/repositories/notifications-repository.unit.test.ts
@@ -1,17 +1,25 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockGet, mockJson } = vi.hoisted(() => ({
+const { mockGet, mockPatch, mockPost, mockJson } = vi.hoisted(() => ({
 	mockGet: vi.fn(),
+	mockPatch: vi.fn(),
+	mockPost: vi.fn(),
 	mockJson: vi.fn(),
 }));
 
 vi.mock('@/lib/api/client', () => ({
 	apiClient: {
 		get: mockGet,
+		patch: mockPatch,
+		post: mockPost,
 	},
 }));
 
-import { listNotifications } from './notifications-repository';
+import {
+	listNotifications,
+	markAllNotificationsRead,
+	markNotificationRead,
+} from './notifications-repository';
 
 const validItem = {
 	id: 'd51b78c5-1847-49dc-826f-461c87974c60',
@@ -92,5 +100,52 @@ describe('listNotifications', () => {
 			nextCursor: null,
 			unreadCount: 2,
 		});
+	});
+});
+
+describe('notification read mutations', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockJson.mockResolvedValue(validItem);
+		mockPatch.mockReturnValue({ json: mockJson });
+		mockPost.mockReturnValue({ json: mockJson });
+	});
+
+	it('marks one notification read without a request body and parses the response', async () => {
+		const readItem = { ...validItem, readAt: '2026-07-18T11:00:00Z' };
+		mockJson.mockResolvedValueOnce(readItem);
+
+		await expect(markNotificationRead(validItem.id)).resolves.toEqual(readItem);
+
+		expect(mockPatch).toHaveBeenCalledWith(
+			`v1/notifications/${validItem.id}/read`
+		);
+		expect(mockJson).toHaveBeenCalledOnce();
+	});
+
+	it('rejects an invalid individual response', async () => {
+		mockJson.mockResolvedValueOnce({ ...validItem, readAt: 123 });
+
+		await expect(markNotificationRead(validItem.id)).rejects.toThrow();
+	});
+
+	it('marks all notifications read without a request body and parses the counts', async () => {
+		const response = { updatedCount: 3, unreadCount: 0 };
+		mockJson.mockResolvedValueOnce(response);
+
+		await expect(markAllNotificationsRead()).resolves.toEqual(response);
+
+		expect(mockPost).toHaveBeenCalledWith('v1/notifications/read-all');
+		expect(mockJson).toHaveBeenCalledOnce();
+	});
+
+	it('rejects extra fields in the bulk response', async () => {
+		mockJson.mockResolvedValueOnce({
+			updatedCount: 3,
+			unreadCount: 0,
+			readAt: '2026-07-18T11:00:00Z',
+		});
+
+		await expect(markAllNotificationsRead()).rejects.toThrow();
 	});
 });

--- a/src/features/notifications/schemas/index.ts
+++ b/src/features/notifications/schemas/index.ts
@@ -5,3 +5,7 @@ export {
 	notificationListEnvelopeSchema,
 	parseNotificationListResponse,
 } from './notification-list.schema';
+export {
+	markAllNotificationsReadResponseSchema,
+	parseMarkAllNotificationsReadResponse,
+} from './notification-read.schema';

--- a/src/features/notifications/schemas/notification-read.schema.ts
+++ b/src/features/notifications/schemas/notification-read.schema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+import type { MarkAllNotificationsReadResponse } from '../models';
+
+export const markAllNotificationsReadResponseSchema = z
+	.object({
+		updatedCount: z.number().int().nonnegative(),
+		unreadCount: z.number().int().nonnegative(),
+	})
+	.strict();
+
+export const parseMarkAllNotificationsReadResponse = (
+	data: unknown
+): MarkAllNotificationsReadResponse =>
+	markAllNotificationsReadResponseSchema.parse(data);

--- a/src/features/notifications/schemas/notification-read.schema.unit.test.ts
+++ b/src/features/notifications/schemas/notification-read.schema.unit.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { parseMarkAllNotificationsReadResponse } from './notification-read.schema';
+
+describe('notification read schemas', () => {
+	it('parses the strict bulk-read response', () => {
+		expect(
+			parseMarkAllNotificationsReadResponse({
+				updatedCount: 2,
+				unreadCount: 0,
+			})
+		).toEqual({ updatedCount: 2, unreadCount: 0 });
+	});
+
+	it('rejects missing, invalid, and extra bulk-read fields', () => {
+		expect(() =>
+			parseMarkAllNotificationsReadResponse({ updatedCount: 2 })
+		).toThrow();
+		expect(() =>
+			parseMarkAllNotificationsReadResponse({
+				updatedCount: -1,
+				unreadCount: 0,
+			})
+		).toThrow();
+		expect(() =>
+			parseMarkAllNotificationsReadResponse({
+				updatedCount: 2,
+				unreadCount: 0,
+				extra: true,
+			})
+		).toThrow();
+	});
+});

--- a/src/features/notifications/stores/useNotificationsStore.ts
+++ b/src/features/notifications/stores/useNotificationsStore.ts
@@ -1,7 +1,11 @@
 import { create } from 'zustand';
 import { createLatestRequestGuard } from '@/lib/utilities/latest-request-guard';
 import type { NotificationBaseResponse } from '../models';
-import { listNotifications } from '../repositories';
+import {
+	listNotifications,
+	markAllNotificationsRead,
+	markNotificationRead,
+} from '../repositories';
 
 interface NotificationsStore {
 	items: NotificationBaseResponse[];
@@ -10,11 +14,15 @@ interface NotificationsStore {
 	unreadOnly: boolean;
 	isLoading: boolean;
 	isLoadingMore: boolean;
+	pendingReadId: string | null;
+	isMarkingAllRead: boolean;
 	error: string | null;
 	hasLoaded: boolean;
 	loadNotifications: () => Promise<void>;
 	loadMore: () => Promise<void>;
 	setUnreadOnly: (unreadOnly: boolean) => Promise<void>;
+	markAsRead: (notificationId: string) => Promise<void>;
+	markAllAsRead: () => Promise<void>;
 	reset: () => void;
 }
 
@@ -25,6 +33,8 @@ const initialState = {
 	unreadOnly: false,
 	isLoading: false,
 	isLoadingMore: false,
+	pendingReadId: null as string | null,
+	isMarkingAllRead: false,
 	error: null as string | null,
 	hasLoaded: false,
 };
@@ -109,6 +119,73 @@ export const useNotificationsStore = create<NotificationsStore>((set, get) => {
 			});
 
 			await get().loadNotifications();
+		},
+
+		markAsRead: async (notificationId) => {
+			const { items, pendingReadId, isMarkingAllRead } = get();
+			const notification = items.find((item) => item.id === notificationId);
+			if (
+				pendingReadId !== null ||
+				isMarkingAllRead ||
+				!notification ||
+				notification.readAt !== null
+			) {
+				return;
+			}
+
+			set({ pendingReadId: notificationId });
+
+			try {
+				const updatedNotification = await markNotificationRead(notificationId);
+
+				set((state) => {
+					const currentNotification = state.items.find(
+						(item) => item.id === notificationId
+					);
+					const becameRead =
+						currentNotification?.readAt === null &&
+						updatedNotification.readAt !== null;
+
+					return {
+						items:
+							state.unreadOnly && becameRead
+								? state.items.filter((item) => item.id !== notificationId)
+								: state.items.map((item) =>
+										item.id === notificationId ? updatedNotification : item
+									),
+						unreadCount: becameRead
+							? Math.max(0, state.unreadCount - 1)
+							: state.unreadCount,
+					};
+				});
+			} finally {
+				set({ pendingReadId: null });
+			}
+		},
+
+		markAllAsRead: async () => {
+			const { unreadCount, pendingReadId, isMarkingAllRead } = get();
+			if (unreadCount === 0 || pendingReadId !== null || isMarkingAllRead) {
+				return;
+			}
+
+			set({ isMarkingAllRead: true });
+
+			try {
+				const result = await markAllNotificationsRead();
+				set({
+					items: [],
+					nextCursor: null,
+					unreadCount: result.unreadCount,
+					error: null,
+					hasLoaded: false,
+					isMarkingAllRead: false,
+				});
+				await get().loadNotifications();
+			} catch (error) {
+				set({ isMarkingAllRead: false });
+				throw error;
+			}
 		},
 
 		reset: () => {

--- a/src/features/notifications/stores/useNotificationsStore.unit.test.ts
+++ b/src/features/notifications/stores/useNotificationsStore.unit.test.ts
@@ -1,11 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockListNotifications } = vi.hoisted(() => ({
+const {
+	mockListNotifications,
+	mockMarkNotificationRead,
+	mockMarkAllNotificationsRead,
+} = vi.hoisted(() => ({
 	mockListNotifications: vi.fn(),
+	mockMarkNotificationRead: vi.fn(),
+	mockMarkAllNotificationsRead: vi.fn(),
 }));
 
 vi.mock('../repositories/notifications-repository', () => ({
 	listNotifications: (...args: unknown[]) => mockListNotifications(...args),
+	markNotificationRead: (...args: unknown[]) =>
+		mockMarkNotificationRead(...args),
+	markAllNotificationsRead: (...args: unknown[]) =>
+		mockMarkAllNotificationsRead(...args),
 }));
 
 import { useNotificationsStore } from './useNotificationsStore';
@@ -50,6 +60,17 @@ const unreadPage = {
 	unreadCount: 1,
 };
 
+const readItem = {
+	...firstPage.items[0],
+	readAt: '2026-07-18T12:34:56Z',
+};
+
+const readPage = {
+	items: [readItem],
+	nextCursor: null,
+	unreadCount: 0,
+};
+
 const initialState = {
 	items: [],
 	nextCursor: null,
@@ -57,6 +78,8 @@ const initialState = {
 	unreadOnly: false,
 	isLoading: false,
 	isLoadingMore: false,
+	pendingReadId: null,
+	isMarkingAllRead: false,
 	error: null,
 	hasLoaded: false,
 };
@@ -67,7 +90,7 @@ describe('useNotificationsStore', () => {
 		useNotificationsStore.setState(initialState);
 	});
 
-	it('has the expected initial values and no read-mutation actions', () => {
+	it('has the expected initial values and read-mutation actions', () => {
 		const state = useNotificationsStore.getState();
 
 		expect(state.items).toEqual([]);
@@ -76,10 +99,12 @@ describe('useNotificationsStore', () => {
 		expect(state.unreadOnly).toBe(false);
 		expect(state.isLoading).toBe(false);
 		expect(state.isLoadingMore).toBe(false);
+		expect(state.pendingReadId).toBeNull();
+		expect(state.isMarkingAllRead).toBe(false);
 		expect(state.error).toBeNull();
 		expect(state.hasLoaded).toBe(false);
-		expect(state).not.toHaveProperty('markAsRead');
-		expect(state).not.toHaveProperty('markAllAsRead');
+		expect(state.markAsRead).toBeTypeOf('function');
+		expect(state.markAllAsRead).toBeTypeOf('function');
 	});
 
 	it('loads the first page and replaces items', async () => {
@@ -201,6 +226,153 @@ describe('useNotificationsStore', () => {
 		expect(useNotificationsStore.getState().unreadOnly).toBe(true);
 	});
 
+	it('stores the exact individual response and serializes repeated reads', async () => {
+		let resolveRead: (value: typeof readItem) => void;
+		mockMarkNotificationRead.mockReturnValueOnce(
+			new Promise((resolve) => {
+				resolveRead = resolve;
+			})
+		);
+		useNotificationsStore.setState({
+			...firstPage,
+			hasLoaded: true,
+		});
+
+		const firstRead = useNotificationsStore.getState().markAsRead('n-1');
+		const repeatedRead = useNotificationsStore.getState().markAsRead('n-1');
+
+		expect(useNotificationsStore.getState().pendingReadId).toBe('n-1');
+		expect(mockMarkNotificationRead).toHaveBeenCalledOnce();
+
+		resolveRead!(readItem);
+		await Promise.all([firstRead, repeatedRead]);
+
+		expect(useNotificationsStore.getState().items).toEqual([readItem]);
+		expect(useNotificationsStore.getState().items[0].readAt).toBe(
+			'2026-07-18T12:34:56Z'
+		);
+		expect(useNotificationsStore.getState().unreadCount).toBe(1);
+		expect(useNotificationsStore.getState().pendingReadId).toBeNull();
+	});
+
+	it('removes an individually read item from the unread-only view', async () => {
+		mockMarkNotificationRead.mockResolvedValueOnce(readItem);
+		useNotificationsStore.setState({
+			...unreadPage,
+			unreadOnly: true,
+			hasLoaded: true,
+		});
+
+		await useNotificationsStore.getState().markAsRead('n-1');
+
+		expect(useNotificationsStore.getState().items).toEqual([]);
+		expect(useNotificationsStore.getState().unreadCount).toBe(0);
+	});
+
+	it('does not request an individual read for missing or already-read items', async () => {
+		useNotificationsStore.setState({
+			items: secondPage.items,
+			hasLoaded: true,
+		});
+
+		await useNotificationsStore.getState().markAsRead('missing');
+		await useNotificationsStore.getState().markAsRead('n-2');
+
+		expect(mockMarkNotificationRead).not.toHaveBeenCalled();
+	});
+
+	it('restores individual read controls and rethrows on failure', async () => {
+		mockMarkNotificationRead.mockRejectedValueOnce(new Error('Read failed'));
+		useNotificationsStore.setState({
+			...firstPage,
+			hasLoaded: true,
+		});
+
+		await expect(
+			useNotificationsStore.getState().markAsRead('n-1')
+		).rejects.toThrow('Read failed');
+
+		expect(useNotificationsStore.getState().pendingReadId).toBeNull();
+		expect(useNotificationsStore.getState().items).toEqual(firstPage.items);
+	});
+
+	it('applies bulk counts, resets pagination, and reloads the first page', async () => {
+		mockMarkAllNotificationsRead.mockResolvedValueOnce({
+			updatedCount: 2,
+			unreadCount: 0,
+		});
+		mockListNotifications.mockResolvedValueOnce(readPage);
+		useNotificationsStore.setState({
+			...firstPage,
+			hasLoaded: true,
+		});
+
+		const pending = useNotificationsStore.getState().markAllAsRead();
+		const repeated = useNotificationsStore.getState().markAllAsRead();
+		const overlappingIndividual = useNotificationsStore
+			.getState()
+			.markAsRead('n-1');
+		expect(useNotificationsStore.getState().isMarkingAllRead).toBe(true);
+
+		await Promise.all([pending, repeated, overlappingIndividual]);
+
+		expect(mockMarkAllNotificationsRead).toHaveBeenCalledOnce();
+		expect(mockMarkNotificationRead).not.toHaveBeenCalled();
+		expect(mockListNotifications).toHaveBeenCalledWith({ unreadOnly: false });
+		expect(useNotificationsStore.getState()).toMatchObject({
+			items: readPage.items,
+			nextCursor: null,
+			unreadCount: 0,
+			isMarkingAllRead: false,
+		});
+	});
+
+	it('uses the standard list error state when the post-bulk refresh fails', async () => {
+		const consoleSpy = vi
+			.spyOn(console, 'error')
+			.mockImplementation(() => undefined);
+		mockMarkAllNotificationsRead.mockResolvedValueOnce({
+			updatedCount: 2,
+			unreadCount: 0,
+		});
+		mockListNotifications.mockRejectedValueOnce(new Error('Refresh failed'));
+		useNotificationsStore.setState({
+			...firstPage,
+			hasLoaded: true,
+		});
+
+		await expect(
+			useNotificationsStore.getState().markAllAsRead()
+		).resolves.toBeUndefined();
+
+		expect(useNotificationsStore.getState()).toMatchObject({
+			items: [],
+			unreadCount: 0,
+			isMarkingAllRead: false,
+			error: 'Refresh failed',
+			hasLoaded: true,
+		});
+		consoleSpy.mockRestore();
+	});
+
+	it('restores bulk controls and rethrows when the mutation fails', async () => {
+		mockMarkAllNotificationsRead.mockRejectedValueOnce(
+			new Error('Bulk failed')
+		);
+		useNotificationsStore.setState({
+			...firstPage,
+			hasLoaded: true,
+		});
+
+		await expect(
+			useNotificationsStore.getState().markAllAsRead()
+		).rejects.toThrow('Bulk failed');
+
+		expect(useNotificationsStore.getState().isMarkingAllRead).toBe(false);
+		expect(useNotificationsStore.getState().items).toEqual(firstPage.items);
+		expect(mockListNotifications).not.toHaveBeenCalled();
+	});
+
 	it('resets store state', () => {
 		useNotificationsStore.setState({
 			items: firstPage.items,
@@ -210,6 +382,8 @@ describe('useNotificationsStore', () => {
 			isLoading: true,
 			error: 'boom',
 			hasLoaded: true,
+			pendingReadId: 'n-1',
+			isMarkingAllRead: true,
 		});
 
 		useNotificationsStore.getState().reset();

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -361,6 +361,8 @@
 	"NotificationsPage": {
 		"pageTitle": "Cinelog - Notifications",
 		"title": "Notifications",
+		"markAllAsRead": "Mark all as read",
+		"markAllAsReadError": "Could not mark all notifications as read",
 		"unreadOnly": "Unread only",
 		"loading": "Loading notifications...",
 		"empty": "No notifications yet",
@@ -370,6 +372,8 @@
 		"loadMore": "Load more"
 	},
 	"NotificationItem": {
+		"markAsRead": "Mark as read",
+		"markAsReadError": "Could not mark this notification as read",
 		"follow": {
 			"started": {
 				"withActor": "<actor>{{firstName}} {{lastName}}</actor> started following you",

--- a/src/lib/locales/fr.json
+++ b/src/lib/locales/fr.json
@@ -361,6 +361,8 @@
 	"NotificationsPage": {
 		"pageTitle": "Cinelog - Notifications",
 		"title": "Notifications",
+		"markAllAsRead": "Tout marquer comme lu",
+		"markAllAsReadError": "Impossible de marquer toutes les notifications comme lues",
 		"unreadOnly": "Non lues uniquement",
 		"loading": "Chargement des notifications...",
 		"empty": "Aucune notification",
@@ -370,6 +372,8 @@
 		"loadMore": "Charger plus"
 	},
 	"NotificationItem": {
+		"markAsRead": "Marquer comme lue",
+		"markAsReadError": "Impossible de marquer cette notification comme lue",
 		"follow": {
 			"started": {
 				"withActor": "<actor>{{firstName}} {{lastName}}</actor> a commencé à vous suivre",

--- a/src/lib/locales/it.json
+++ b/src/lib/locales/it.json
@@ -361,6 +361,8 @@
 	"NotificationsPage": {
 		"pageTitle": "Cinelog - Notifiche",
 		"title": "Notifiche",
+		"markAllAsRead": "Segna tutte come lette",
+		"markAllAsReadError": "Impossibile segnare tutte le notifiche come lette",
 		"unreadOnly": "Solo non lette",
 		"loading": "Caricamento delle notifiche...",
 		"empty": "Nessuna notifica",
@@ -370,6 +372,8 @@
 		"loadMore": "Carica altri"
 	},
 	"NotificationItem": {
+		"markAsRead": "Segna come letta",
+		"markAsReadError": "Impossibile segnare la notifica come letta",
 		"follow": {
 			"started": {
 				"withActor": "<actor>{{firstName}} {{lastName}}</actor> ha iniziato a seguirti",


### PR DESCRIPTION
## Summary

- add strict repository contracts for individual and bulk notification read mutations
- synchronize exact server-owned read timestamps, unread filtering, counts, and bulk first-page refresh in the existing store
- add localized individual and bulk controls with accessible pending and retryable error states

## Testing

- `bun run test:unit` — 851 passed
- `bun run test:integration` — 70 passed
- `bun run check:locales`
- `bun run lint`
- `bun run build`
- `git diff --check`

## Accessibility

- native text buttons retain keyboard behavior and visible labels
- pending mutations expose disabled and `aria-busy` states
- heading controls wrap at narrow viewports
- authenticated live-browser verification was unavailable because the local backend/session was not running; component and integration role/state checks passed

## Screenshots

Not available: the local backend and authenticated browser session were unavailable during verification.

Closes #93